### PR TITLE
fix: downgrade markdown-link-check

### DIFF
--- a/linter.js
+++ b/linter.js
@@ -218,7 +218,7 @@ const clearconfigOption = new Option('-l, --clearconfig', 'remove markdownlint c
 program
   .name('foliant-md-linter')
   .description('CLI tool for linting Foliant markdown sources')
-  .version('0.0.1')
+  .version('0.1.10')
 
 program.command('full-check')
   .description('Check md files with markdownlint and markdown-link-check')

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "foliant-md-linter",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "description": "CLI tool for linting Foliant markdown sources",
   "license": "MIT",
   "homepage": "https://github.com/holamgadol/foliant-md-linter",
@@ -19,10 +19,10 @@
     "validate": "npm run lint && npm test"
   },
   "dependencies": {
-    "commander": "^10.0.0",
-    "markdown-link-check": "^3.10.3",
+    "commander": "^9.1.0",
+    "markdown-link-check": "~3.10.3",
     "markdownlint-cli2": "^0.6.0",
-    "markdownlint-rules-foliant": "^0.1.9"
+    "markdownlint-rules-foliant": "latest"
   },
   "devDependencies": {
     "eslint": "^7.32.0",


### PR DESCRIPTION
reason: [Configuration file reading is broken in 3.11.0](https://github.com/tcort/markdown-link-check/issues/246)