### PR TITLE
feat: rule for checking for tags in frontmatter to config

### DIFF
--- a/generate.js
+++ b/generate.js
@@ -15,7 +15,7 @@ function createConfig (mode = 'full', source = '', project = '') {
       path.join(__dirname, '/node_modules/markdownlint-rules-foliant/lib/fenced-code-in-quote'),
       path.join(__dirname, '/node_modules/markdownlint-rules-foliant/lib/typograph'),
       path.join(__dirname, '/node_modules/markdownlint-rules-foliant/lib/validate-internal-links'),
-      path.join(__dirname, '/node_modules/markdownlint-rules-foliant/lib/checking-frontmatter-tags')
+      path.join(__dirname, '/node_modules/markdownlint-rules-foliant/lib/frontmatter-tags-exist')
     ]
   } else {
     customRules = [
@@ -24,7 +24,7 @@ function createConfig (mode = 'full', source = '', project = '') {
       path.resolve(__dirname, '../markdownlint-rules-foliant/lib/fenced-code-in-quote'),
       path.resolve(__dirname, '../markdownlint-rules-foliant/lib/typograph'),
       path.resolve(__dirname, '../markdownlint-rules-foliant/lib/validate-internal-links'),
-      path.resolve(__dirname, '../markdownlint-rules-foliant/lib/checking-frontmatter-tags')
+      path.resolve(__dirname, '../markdownlint-rules-foliant/lib/frontmatter-tags-exist')
     ]
   }
 
@@ -76,7 +76,7 @@ function createConfig (mode = 'full', source = '', project = '') {
       src: source.length === 0 ? undefined : source,
       project: project.length === 0 ? undefined : project
     },
-    'checking-frontmatter-tags': true
+    'frontmatter-tags-exist': true
   }
 
   const configSlim = {
@@ -125,7 +125,7 @@ function createConfig (mode = 'full', source = '', project = '') {
       src: source.length === 0 ? undefined : source,
       project: project.length === 0 ? undefined : project
     },
-    'checking-frontmatter-tags': false
+    'frontmatter-tags-exist': false
   }
 
   const configTypograph = {
@@ -180,7 +180,7 @@ function createConfig (mode = 'full', source = '', project = '') {
     'fenced-code-in-quote': false,
     typograph: true,
     'validate-internal-links': false,
-    'checking-frontmatter-tags': true
+    'frontmatter-tags-exist': true
   }
 
   let config

--- a/generate.js
+++ b/generate.js
@@ -54,7 +54,7 @@ function createConfig (mode = 'full', source = '', project = '') {
     MD031: true,
     MD032: false,
     MD033: false,
-    MD034: true,
+    MD034: false,
     MD036: true,
     MD037: true,
     MD038: true,
@@ -76,7 +76,7 @@ function createConfig (mode = 'full', source = '', project = '') {
       src: source.length === 0 ? undefined : source,
       project: project.length === 0 ? undefined : project
     },
-    'frontmatter-tags-exist': true
+    'frontmatter-tags-exist': false
   }
 
   const configSlim = {
@@ -102,7 +102,7 @@ function createConfig (mode = 'full', source = '', project = '') {
     MD031: false,
     MD032: false,
     MD033: false,
-    MD034: true,
+    MD034: false,
     MD036: false,
     MD037: false,
     MD038: false,
@@ -180,7 +180,7 @@ function createConfig (mode = 'full', source = '', project = '') {
     'fenced-code-in-quote': false,
     typograph: true,
     'validate-internal-links': false,
-    'frontmatter-tags-exist': true
+    'frontmatter-tags-exist': false
   }
 
   let config

--- a/generate.js
+++ b/generate.js
@@ -14,7 +14,8 @@ function createConfig (mode = 'full', source = '', project = '') {
       path.join(__dirname, '/node_modules/markdownlint-rules-foliant/lib/non-literal-fence-label'),
       path.join(__dirname, '/node_modules/markdownlint-rules-foliant/lib/fenced-code-in-quote'),
       path.join(__dirname, '/node_modules/markdownlint-rules-foliant/lib/typograph'),
-      path.join(__dirname, '/node_modules/markdownlint-rules-foliant/lib/validate-internal-links')
+      path.join(__dirname, '/node_modules/markdownlint-rules-foliant/lib/validate-internal-links'),
+      path.join(__dirname, '/node_modules/markdownlint-rules-foliant/lib/checking-frontmatter-tags')
     ]
   } else {
     customRules = [
@@ -22,8 +23,8 @@ function createConfig (mode = 'full', source = '', project = '') {
       path.resolve(__dirname, '../markdownlint-rules-foliant/lib/non-literal-fence-label'),
       path.resolve(__dirname, '../markdownlint-rules-foliant/lib/fenced-code-in-quote'),
       path.resolve(__dirname, '../markdownlint-rules-foliant/lib/typograph'),
-      path.resolve(__dirname, '../markdownlint-rules-foliant/lib/validate-internal-links')
-
+      path.resolve(__dirname, '../markdownlint-rules-foliant/lib/validate-internal-links'),
+      path.resolve(__dirname, '../markdownlint-rules-foliant/lib/checking-frontmatter-tags')
     ]
   }
 
@@ -74,7 +75,8 @@ function createConfig (mode = 'full', source = '', project = '') {
     'validate-internal-links': {
       src: source.length === 0 ? undefined : source,
       project: project.length === 0 ? undefined : project
-    }
+    },
+    'checking-frontmatter-tags': true
   }
 
   const configSlim = {
@@ -122,7 +124,8 @@ function createConfig (mode = 'full', source = '', project = '') {
     'validate-internal-links': {
       src: source.length === 0 ? undefined : source,
       project: project.length === 0 ? undefined : project
-    }
+    },
+    'checking-frontmatter-tags': false
   }
 
   const configTypograph = {
@@ -176,7 +179,8 @@ function createConfig (mode = 'full', source = '', project = '') {
     'non-literal-fence-label': false,
     'fenced-code-in-quote': false,
     typograph: true,
-    'validate-internal-links': false
+    'validate-internal-links': false,
+    'checking-frontmatter-tags': true
   }
 
   let config

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "commander": "^9.1.0",
     "markdown-link-check": "~3.10.3",
     "markdownlint-cli2": "^0.6.0",
-    "markdownlint-rules-foliant": "holamgadol/markdownlint-foliant-rules#feat-frontmatter-tags"
+    "markdownlint-rules-foliant": "latest"
   },
   "devDependencies": {
     "eslint": "^7.32.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "foliant-md-linter",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "description": "CLI tool for linting Foliant markdown sources",
   "license": "MIT",
   "homepage": "https://github.com/holamgadol/foliant-md-linter",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "commander": "^9.1.0",
     "markdown-link-check": "~3.10.3",
     "markdownlint-cli2": "^0.6.0",
-    "markdownlint-rules-foliant": "latest"
+    "markdownlint-rules-foliant": "holamgadol/markdownlint-foliant-rules#feat-frontmatter-tags"
   },
   "devDependencies": {
     "eslint": "^7.32.0",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "commander": "^9.1.0",
     "markdown-link-check": "~3.10.3",
     "markdownlint-cli2": "^0.6.0",
-    "markdownlint-rules-foliant": "holamgadol/markdownlint-foliant-rules#feat-frontmatter-tags"
+    "markdownlint-rules-foliant": "holamgadol/markdownlint-rules-foliant#feat-frontmatter-tags"
   },
   "devDependencies": {
     "eslint": "^7.32.0",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "commander": "^9.1.0",
     "markdown-link-check": "~3.10.3",
     "markdownlint-cli2": "^0.6.0",
-    "markdownlint-rules-foliant": "holamgadol/markdownlint-rules-foliant#feat-frontmatter-tags"
+    "markdownlint-rules-foliant": "holamgadol/markdownlint-foliant-rules#feat-frontmatter-tags"
   },
   "devDependencies": {
     "eslint": "^7.32.0",

--- a/test/alt-src/linter-test-B.md
+++ b/test/alt-src/linter-test-B.md
@@ -1,3 +1,6 @@
+---
+tags: none
+---
 # Linter test B
 
 ```non-literal-fence-label{

--- a/test/alt-src/linter-test-B.md
+++ b/test/alt-src/linter-test-B.md
@@ -1,6 +1,8 @@
 ---
-tags: none
+tags:
+    - none
 ---
+
 # Linter test B
 
 ```non-literal-fence-label{

--- a/test/linter.spec.js
+++ b/test/linter.spec.js
@@ -7,7 +7,7 @@ const fs = require('fs')
 
 const cwd = process.cwd().toString()
 const isWin = process.platform === 'win32'
-jest.setTimeout(10000)
+jest.setTimeout(30000)
 
 function linkCheckFilePrint (file) {
   if (process.platform === 'win32') {
@@ -137,19 +137,19 @@ test('slim -v', async () => {
 
     'FILE: src/linter-test-A.md\n',
 
-    'src/linter-test-A.md:3 MD001/heading-increment/header-increment Heading levels should only increment by one level at a time [Expected: h2; Actual: h3]\n',
-    'src/linter-test-A.md:7 indented-fence Fenced code shouldn\'t be indented by 1 to 3 spaces [Context: "   ```bash"]\n',
-    'src/linter-test-A.md:11 non-literal-fence-label Invalid language label in fenced code block\n',
-    'src/linter-test-A.md:18 fenced-code-in-quote Fenced code shouldn\'t be in quote\n',
-    'src/linter-test-A.md:26 validate-internal-links Broken link [image does not exist] [Context: "/red-circle.png"]\n',
-    'src/linter-test-A.md:30 validate-internal-links Broken link [file does not exist] [Context: "/another-project/subproject/article"]\n',
-    'src/linter-test-A.md:32 validate-internal-links Broken link [file does not exist] [Context: "/another-project/subproject/article#anchor"]\n',
+    'src/linter-test-A.md:6 MD001/heading-increment/header-increment Heading levels should only increment by one level at a time [Expected: h2; Actual: h3]\n',
+    'src/linter-test-A.md:10 indented-fence Fenced code shouldn\'t be indented by 1 to 3 spaces [Context: "   ```bash"]\n',
+    'src/linter-test-A.md:14 non-literal-fence-label Invalid language label in fenced code block\n',
+    'src/linter-test-A.md:21 fenced-code-in-quote Fenced code shouldn\'t be in quote\n',
+    'src/linter-test-A.md:29 validate-internal-links Broken link [image does not exist] [Context: "/red-circle.png"]\n',
+    'src/linter-test-A.md:33 validate-internal-links Broken link [file does not exist] [Context: "/another-project/subproject/article"]\n',
+    'src/linter-test-A.md:35 validate-internal-links Broken link [file does not exist] [Context: "/another-project/subproject/article#anchor"]\n',
 
     '--------------------------------------------------------------------------------\n',
 
     'FILE: src/subproject/article.md\n',
 
-    'src/subproject/article.md:3 validate-internal-links Broken link [invalid local anchor] [Context: "#anchor"]\n',
+    'src/subproject/article.md:6 validate-internal-links Broken link [invalid local anchor] [Context: "#anchor"]\n',
 
     `Full markdownlint log see in ${path.join(cwd, '.markdownlint_slim.log')}\n`]
   const result = await cli(['slim', '-v'], '.')
@@ -169,11 +169,11 @@ test('slim -v -s alt-src', async () => {
 
     'FILE: alt-src/linter-test-B.md\n',
 
-    'alt-src/linter-test-B.md:3 non-literal-fence-label Invalid language label in fenced code block\n',
-    'alt-src/linter-test-B.md:14 MD001/heading-increment/header-increment Heading levels should only increment by one level at a time [Expected: h2; Actual: h3]\n',
-    'alt-src/linter-test-B.md:16 fenced-code-in-quote Fenced code shouldn\'t be in quote\n',
-    'alt-src/linter-test-B.md:20 validate-internal-links Broken link [image does not exist] [Context: "/red-circle.png"]\n',
-    'alt-src/linter-test-B.md:24 indented-fence Fenced code shouldn\'t be indented by 1 to 3 spaces [Context: "   ```bash"]\n',
+    'alt-src/linter-test-B.md:6 non-literal-fence-label Invalid language label in fenced code block\n',
+    'alt-src/linter-test-B.md:17 MD001/heading-increment/header-increment Heading levels should only increment by one level at a time [Expected: h2; Actual: h3]\n',
+    'alt-src/linter-test-B.md:19 fenced-code-in-quote Fenced code shouldn\'t be in quote\n',
+    'alt-src/linter-test-B.md:23 validate-internal-links Broken link [image does not exist] [Context: "/red-circle.png"]\n',
+    'alt-src/linter-test-B.md:27 indented-fence Fenced code shouldn\'t be indented by 1 to 3 spaces [Context: "   ```bash"]\n',
 
     `Full markdownlint log see in ${path.join(cwd, '.markdownlint_slim.log')}\n`]
   const result = await cli(['slim', '-v', '-s alt-src'], '.')
@@ -193,19 +193,19 @@ test('slim -v -p another-project', async () => {
 
     'FILE: src/linter-test-A.md\n',
 
-    'src/linter-test-A.md:3 MD001/heading-increment/header-increment Heading levels should only increment by one level at a time [Expected: h2; Actual: h3]\n',
-    'src/linter-test-A.md:7 indented-fence Fenced code shouldn\'t be indented by 1 to 3 spaces [Context: "   ```bash"]\n',
-    'src/linter-test-A.md:11 non-literal-fence-label Invalid language label in fenced code block\n',
-    'src/linter-test-A.md:18 fenced-code-in-quote Fenced code shouldn\'t be in quote\n',
-    'src/linter-test-A.md:26 validate-internal-links Broken link [image does not exist] [Context: "/red-circle.png"]\n',
-    'src/linter-test-A.md:32 validate-internal-links Broken link [file exists, but invalid anchor] [Context: "/another-project/subproject/article#anchor"]\n',
-    'src/linter-test-A.md:34 validate-internal-links Broken link [file does not exist] [Context: "/foliant-md-linter/subproject/article"]\n',
+    'src/linter-test-A.md:6 MD001/heading-increment/header-increment Heading levels should only increment by one level at a time [Expected: h2; Actual: h3]\n',
+    'src/linter-test-A.md:10 indented-fence Fenced code shouldn\'t be indented by 1 to 3 spaces [Context: "   ```bash"]\n',
+    'src/linter-test-A.md:14 non-literal-fence-label Invalid language label in fenced code block\n',
+    'src/linter-test-A.md:21 fenced-code-in-quote Fenced code shouldn\'t be in quote\n',
+    'src/linter-test-A.md:29 validate-internal-links Broken link [image does not exist] [Context: "/red-circle.png"]\n',
+    'src/linter-test-A.md:35 validate-internal-links Broken link [file exists, but invalid anchor] [Context: "/another-project/subproject/article#anchor"]\n',
+    'src/linter-test-A.md:37 validate-internal-links Broken link [file does not exist] [Context: "/foliant-md-linter/subproject/article"]\n',
 
     '--------------------------------------------------------------------------------\n',
 
     'FILE: src/subproject/article.md\n',
 
-    'src/subproject/article.md:3 validate-internal-links Broken link [invalid local anchor] [Context: "#anchor"]\n',
+    'src/subproject/article.md:6 validate-internal-links Broken link [invalid local anchor] [Context: "#anchor"]\n',
 
     `Full markdownlint log see in ${path.join(cwd, '.markdownlint_slim.log')}\n`]
   const result = await cli(['slim', '-v', '-p another-project'], '.')
@@ -225,19 +225,19 @@ test('slim -v -p another-project -f', async () => {
 
     'FILE: src/linter-test-A.md\n',
 
-    'src/linter-test-A.md:3 MD001/heading-increment/header-increment Heading levels should only increment by one level at a time [Expected: h2; Actual: h3]\n',
-    'src/linter-test-A.md:7 indented-fence Fenced code shouldn\'t be indented by 1 to 3 spaces [Context: "   ```bash"]\n',
-    'src/linter-test-A.md:11 non-literal-fence-label Invalid language label in fenced code block\n',
-    'src/linter-test-A.md:18 fenced-code-in-quote Fenced code shouldn\'t be in quote\n',
-    'src/linter-test-A.md:26 validate-internal-links Broken link [image does not exist] [Context: "/red-circle.png"]\n',
-    'src/linter-test-A.md:32 validate-internal-links Broken link [file exists, but invalid anchor] [Context: "/another-project/subproject/article#anchor"]\n',
-    'src/linter-test-A.md:34 validate-internal-links Broken link [file does not exist] [Context: "/foliant-md-linter/subproject/article"]\n',
+    'src/linter-test-A.md:6 MD001/heading-increment/header-increment Heading levels should only increment by one level at a time [Expected: h2; Actual: h3]\n',
+    'src/linter-test-A.md:10 indented-fence Fenced code shouldn\'t be indented by 1 to 3 spaces [Context: "   ```bash"]\n',
+    'src/linter-test-A.md:14 non-literal-fence-label Invalid language label in fenced code block\n',
+    'src/linter-test-A.md:21 fenced-code-in-quote Fenced code shouldn\'t be in quote\n',
+    'src/linter-test-A.md:29 validate-internal-links Broken link [image does not exist] [Context: "/red-circle.png"]\n',
+    'src/linter-test-A.md:35 validate-internal-links Broken link [file exists, but invalid anchor] [Context: "/another-project/subproject/article#anchor"]\n',
+    'src/linter-test-A.md:37 validate-internal-links Broken link [file does not exist] [Context: "/foliant-md-linter/subproject/article"]\n',
 
     '--------------------------------------------------------------------------------\n',
 
     'FILE: src/subproject/article.md\n',
 
-    'src/subproject/article.md:3 validate-internal-links Broken link [invalid local anchor] [Context: "#anchor"]\n',
+    'src/subproject/article.md:6 validate-internal-links Broken link [invalid local anchor] [Context: "#anchor"]\n',
 
     `Full markdownlint log see in ${path.join(cwd, '.markdownlint_slim.log')}\n`]
   const result = await cli(['slim', '-v', '-p another-project', '-f'], '.')
@@ -303,19 +303,19 @@ test('styleguide -v', async () => {
 
     'FILE: src/linter-test-A.md\n',
 
-    'src/linter-test-A.md:3 MD001/heading-increment/header-increment Heading levels should only increment by one level at a time [Expected: h2; Actual: h3]\n',
-    'src/linter-test-A.md:7 indented-fence Fenced code shouldn\'t be indented by 1 to 3 spaces [Context: "   ```bash"]\n',
-    'src/linter-test-A.md:11 non-literal-fence-label Invalid language label in fenced code block\n',
-    'src/linter-test-A.md:18 fenced-code-in-quote Fenced code shouldn\'t be in quote\n',
-    'src/linter-test-A.md:26 validate-internal-links Broken link [image does not exist] [Context: "/red-circle.png"]\n',
-    'src/linter-test-A.md:30 validate-internal-links Broken link [file does not exist] [Context: "/another-project/subproject/article"]\n',
-    'src/linter-test-A.md:32 validate-internal-links Broken link [file does not exist] [Context: "/another-project/subproject/article#anchor"]\n',
+    'src/linter-test-A.md:6 MD001/heading-increment/header-increment Heading levels should only increment by one level at a time [Expected: h2; Actual: h3]\n',
+    'src/linter-test-A.md:10 indented-fence Fenced code shouldn\'t be indented by 1 to 3 spaces [Context: "   ```bash"]\n',
+    'src/linter-test-A.md:14 non-literal-fence-label Invalid language label in fenced code block\n',
+    'src/linter-test-A.md:21 fenced-code-in-quote Fenced code shouldn\'t be in quote\n',
+    'src/linter-test-A.md:29 validate-internal-links Broken link [image does not exist] [Context: "/red-circle.png"]\n',
+    'src/linter-test-A.md:33 validate-internal-links Broken link [file does not exist] [Context: "/another-project/subproject/article"]\n',
+    'src/linter-test-A.md:35 validate-internal-links Broken link [file does not exist] [Context: "/another-project/subproject/article#anchor"]\n',
 
     '--------------------------------------------------------------------------------\n',
 
     'FILE: src/subproject/article.md\n',
 
-    'src/subproject/article.md:3 validate-internal-links Broken link [invalid local anchor] [Context: "#anchor"]\n',
+    'src/subproject/article.md:6 validate-internal-links Broken link [invalid local anchor] [Context: "#anchor"]\n',
 
     `Full markdownlint log see in ${path.join(cwd, '.markdownlint_slim.log')}\n`,
 
@@ -338,19 +338,19 @@ test('styleguide -v -p another-project', async () => {
 
     'FILE: src/linter-test-A.md\n',
 
-    'src/linter-test-A.md:3 MD001/heading-increment/header-increment Heading levels should only increment by one level at a time [Expected: h2; Actual: h3]\n',
-    'src/linter-test-A.md:7 indented-fence Fenced code shouldn\'t be indented by 1 to 3 spaces [Context: "   ```bash"]\n',
-    'src/linter-test-A.md:11 non-literal-fence-label Invalid language label in fenced code block\n',
-    'src/linter-test-A.md:18 fenced-code-in-quote Fenced code shouldn\'t be in quote\n',
-    'src/linter-test-A.md:26 validate-internal-links Broken link [image does not exist] [Context: "/red-circle.png"]\n',
-    'src/linter-test-A.md:32 validate-internal-links Broken link [file exists, but invalid anchor] [Context: "/another-project/subproject/article#anchor"]\n',
-    'src/linter-test-A.md:34 validate-internal-links Broken link [file does not exist] [Context: "/foliant-md-linter/subproject/article"]\n',
+    'src/linter-test-A.md:6 MD001/heading-increment/header-increment Heading levels should only increment by one level at a time [Expected: h2; Actual: h3]\n',
+    'src/linter-test-A.md:10 indented-fence Fenced code shouldn\'t be indented by 1 to 3 spaces [Context: "   ```bash"]\n',
+    'src/linter-test-A.md:14 non-literal-fence-label Invalid language label in fenced code block\n',
+    'src/linter-test-A.md:21 fenced-code-in-quote Fenced code shouldn\'t be in quote\n',
+    'src/linter-test-A.md:29 validate-internal-links Broken link [image does not exist] [Context: "/red-circle.png"]\n',
+    'src/linter-test-A.md:35 validate-internal-links Broken link [file exists, but invalid anchor] [Context: "/another-project/subproject/article#anchor"]\n',
+    'src/linter-test-A.md:37 validate-internal-links Broken link [file does not exist] [Context: "/foliant-md-linter/subproject/article"]\n',
 
     '--------------------------------------------------------------------------------\n',
 
     'FILE: src/subproject/article.md\n',
 
-    'src/subproject/article.md:3 validate-internal-links Broken link [invalid local anchor] [Context: "#anchor"]\n',
+    'src/subproject/article.md:6 validate-internal-links Broken link [invalid local anchor] [Context: "#anchor"]\n',
 
     `Full markdownlint log see in ${path.join(cwd, '.markdownlint_slim.log')}\n`,
 
@@ -373,11 +373,11 @@ test('styleguide -s alt-src -v', async () => {
 
     'FILE: alt-src/linter-test-B.md\n',
 
-    'alt-src/linter-test-B.md:3 non-literal-fence-label Invalid language label in fenced code block\n',
-    'alt-src/linter-test-B.md:14 MD001/heading-increment/header-increment Heading levels should only increment by one level at a time [Expected: h2; Actual: h3]\n',
-    'alt-src/linter-test-B.md:16 fenced-code-in-quote Fenced code shouldn\'t be in quote\n',
-    'alt-src/linter-test-B.md:20 validate-internal-links Broken link [image does not exist] [Context: "/red-circle.png"]\n',
-    'alt-src/linter-test-B.md:24 indented-fence Fenced code shouldn\'t be indented by 1 to 3 spaces [Context: "   ```bash"]\n',
+    'alt-src/linter-test-B.md:6 non-literal-fence-label Invalid language label in fenced code block\n',
+    'alt-src/linter-test-B.md:17 MD001/heading-increment/header-increment Heading levels should only increment by one level at a time [Expected: h2; Actual: h3]\n',
+    'alt-src/linter-test-B.md:19 fenced-code-in-quote Fenced code shouldn\'t be in quote\n',
+    'alt-src/linter-test-B.md:23 validate-internal-links Broken link [image does not exist] [Context: "/red-circle.png"]\n',
+    'alt-src/linter-test-B.md:27 indented-fence Fenced code shouldn\'t be indented by 1 to 3 spaces [Context: "   ```bash"]\n',
 
     `Full markdownlint log see in ${path.join(cwd, '.markdownlint_slim.log')}\n`,
 
@@ -400,8 +400,8 @@ test('styleguide -s alt-src -v -c', async () => {
 
     'FILE: alt-src/linter-test-B.md\n',
 
-    'alt-src/linter-test-B.md:14 MD001/heading-increment/header-increment Heading levels should only increment by one level at a time [Expected: h2; Actual: h3]\n',
-    'alt-src/linter-test-B.md:28 MD024/no-duplicate-heading/no-duplicate-header Multiple headings with the same content [Context: "### MD001: Heading levels shou..."]\n',
+    'alt-src/linter-test-B.md:17 MD001/heading-increment/header-increment Heading levels should only increment by one level at a time [Expected: h2; Actual: h3]\n',
+    'alt-src/linter-test-B.md:31 MD024/no-duplicate-heading/no-duplicate-header Multiple headings with the same content [Context: "### MD001: Heading levels shou..."]\n',
 
     `Full markdownlint log see in ${path.join(cwd, '.markdownlint_slim.log')}\n`,
 
@@ -424,8 +424,8 @@ test('styleguide -s alt-src -v -c -f', async () => {
 
     'FILE: alt-src/linter-test-B.md\n',
 
-    'alt-src/linter-test-B.md:14 MD001/heading-increment/header-increment Heading levels should only increment by one level at a time [Expected: h2; Actual: h3]\n',
-    'alt-src/linter-test-B.md:28 MD024/no-duplicate-heading/no-duplicate-header Multiple headings with the same content [Context: "### MD001: Heading levels shou..."]\n',
+    'alt-src/linter-test-B.md:17 MD001/heading-increment/header-increment Heading levels should only increment by one level at a time [Expected: h2; Actual: h3]\n',
+    'alt-src/linter-test-B.md:31 MD024/no-duplicate-heading/no-duplicate-header Multiple headings with the same content [Context: "### MD001: Heading levels shou..."]\n',
 
     `Full markdownlint log see in ${path.join(cwd, '.markdownlint_slim.log')}\n`,
 
@@ -494,19 +494,19 @@ test('fix -v', async () => {
 
     'FILE: src/linter-test-A.md\n',
 
-    'src/linter-test-A.md:3 MD001/heading-increment/header-increment Heading levels should only increment by one level at a time [Expected: h2; Actual: h3]\n',
-    'src/linter-test-A.md:7 indented-fence Fenced code shouldn\'t be indented by 1 to 3 spaces [Context: "   ```bash"]\n',
-    'src/linter-test-A.md:11 non-literal-fence-label Invalid language label in fenced code block\n',
-    'src/linter-test-A.md:18 fenced-code-in-quote Fenced code shouldn\'t be in quote\n',
-    'src/linter-test-A.md:26 validate-internal-links Broken link [image does not exist] [Context: "/red-circle.png"]\n',
-    'src/linter-test-A.md:30 validate-internal-links Broken link [file does not exist] [Context: "/another-project/subproject/article"]\n',
-    'src/linter-test-A.md:32 validate-internal-links Broken link [file does not exist] [Context: "/another-project/subproject/article#anchor"]\n',
+    'src/linter-test-A.md:6 MD001/heading-increment/header-increment Heading levels should only increment by one level at a time [Expected: h2; Actual: h3]\n',
+    'src/linter-test-A.md:10 indented-fence Fenced code shouldn\'t be indented by 1 to 3 spaces [Context: "   ```bash"]\n',
+    'src/linter-test-A.md:14 non-literal-fence-label Invalid language label in fenced code block\n',
+    'src/linter-test-A.md:21 fenced-code-in-quote Fenced code shouldn\'t be in quote\n',
+    'src/linter-test-A.md:29 validate-internal-links Broken link [image does not exist] [Context: "/red-circle.png"]\n',
+    'src/linter-test-A.md:33 validate-internal-links Broken link [file does not exist] [Context: "/another-project/subproject/article"]\n',
+    'src/linter-test-A.md:35 validate-internal-links Broken link [file does not exist] [Context: "/another-project/subproject/article#anchor"]\n',
 
     '--------------------------------------------------------------------------------\n',
 
     'FILE: src/subproject/article.md\n',
 
-    'src/subproject/article.md:3 validate-internal-links Broken link [invalid local anchor] [Context: "#anchor"]\n',
+    'src/subproject/article.md:6 validate-internal-links Broken link [invalid local anchor] [Context: "#anchor"]\n',
 
     `Full markdownlint log see in ${path.join(cwd, '.markdownlint_slim.log')}\n`,
 
@@ -529,19 +529,19 @@ test('fix -v -p another-project', async () => {
 
     'FILE: src/linter-test-A.md\n',
 
-    'src/linter-test-A.md:3 MD001/heading-increment/header-increment Heading levels should only increment by one level at a time [Expected: h2; Actual: h3]\n',
-    'src/linter-test-A.md:7 indented-fence Fenced code shouldn\'t be indented by 1 to 3 spaces [Context: "   ```bash"]\n',
-    'src/linter-test-A.md:11 non-literal-fence-label Invalid language label in fenced code block\n',
-    'src/linter-test-A.md:18 fenced-code-in-quote Fenced code shouldn\'t be in quote\n',
-    'src/linter-test-A.md:26 validate-internal-links Broken link [image does not exist] [Context: "/red-circle.png"]\n',
-    'src/linter-test-A.md:32 validate-internal-links Broken link [file exists, but invalid anchor] [Context: "/another-project/subproject/article#anchor"]\n',
-    'src/linter-test-A.md:34 validate-internal-links Broken link [file does not exist] [Context: "/foliant-md-linter/subproject/article"]\n',
+    'src/linter-test-A.md:6 MD001/heading-increment/header-increment Heading levels should only increment by one level at a time [Expected: h2; Actual: h3]\n',
+    'src/linter-test-A.md:10 indented-fence Fenced code shouldn\'t be indented by 1 to 3 spaces [Context: "   ```bash"]\n',
+    'src/linter-test-A.md:14 non-literal-fence-label Invalid language label in fenced code block\n',
+    'src/linter-test-A.md:21 fenced-code-in-quote Fenced code shouldn\'t be in quote\n',
+    'src/linter-test-A.md:29 validate-internal-links Broken link [image does not exist] [Context: "/red-circle.png"]\n',
+    'src/linter-test-A.md:35 validate-internal-links Broken link [file exists, but invalid anchor] [Context: "/another-project/subproject/article#anchor"]\n',
+    'src/linter-test-A.md:37 validate-internal-links Broken link [file does not exist] [Context: "/foliant-md-linter/subproject/article"]\n',
 
     '--------------------------------------------------------------------------------\n',
 
     'FILE: src/subproject/article.md\n',
 
-    'src/subproject/article.md:3 validate-internal-links Broken link [invalid local anchor] [Context: "#anchor"]\n',
+    'src/subproject/article.md:6 validate-internal-links Broken link [invalid local anchor] [Context: "#anchor"]\n',
 
     `Full markdownlint log see in ${path.join(cwd, '.markdownlint_slim.log')}\n`,
 
@@ -564,10 +564,10 @@ test('fix -v -c', async () => {
 
     'FILE: src/linter-test-A.md\n',
 
-    'src/linter-test-A.md:3 MD001/heading-increment/header-increment Heading levels should only increment by one level at a time [Expected: h2; Actual: h3]\n',
-    'src/linter-test-A.md:5 MD024/no-duplicate-heading/no-duplicate-header Multiple headings with the same content [Context: "### MD001: Heading levels shou..."]\n',
+    'src/linter-test-A.md:6 MD001/heading-increment/header-increment Heading levels should only increment by one level at a time [Expected: h2; Actual: h3]\n',
+    'src/linter-test-A.md:8 MD024/no-duplicate-heading/no-duplicate-header Multiple headings with the same content [Context: "### MD001: Heading levels shou..."]\n',
     'FILE: src/subproject/article.md\n',
-    'src/subproject/article.md:3:1 MD051/link-fragments Link fragments should be valid [Context: "[broken local link](#anchor)"]\n',
+    'src/subproject/article.md:6:1 MD051/link-fragments Link fragments should be valid [Context: "[broken local link](#anchor)"]\n',
 
     `Full markdownlint log see in ${path.join(cwd, '.markdownlint_slim.log')}\n`,
 
@@ -590,8 +590,8 @@ test('fix -v -c -s alt-src', async () => {
 
     'FILE: alt-src/linter-test-B.md\n',
 
-    'alt-src/linter-test-B.md:14 MD001/heading-increment/header-increment Heading levels should only increment by one level at a time [Expected: h2; Actual: h3]\n',
-    'alt-src/linter-test-B.md:28 MD024/no-duplicate-heading/no-duplicate-header Multiple headings with the same content [Context: "### MD001: Heading levels shou..."]\n',
+    'alt-src/linter-test-B.md:17 MD001/heading-increment/header-increment Heading levels should only increment by one level at a time [Expected: h2; Actual: h3]\n',
+    'alt-src/linter-test-B.md:31 MD024/no-duplicate-heading/no-duplicate-header Multiple headings with the same content [Context: "### MD001: Heading levels shou..."]\n',
 
     `Full markdownlint log see in ${path.join(cwd, '.markdownlint_slim.log')}\n`,
 
@@ -614,8 +614,8 @@ test('fix -v -c -s alt-src -f', async () => {
 
     'FILE: alt-src/linter-test-B.md\n',
 
-    'alt-src/linter-test-B.md:14 MD001/heading-increment/header-increment Heading levels should only increment by one level at a time [Expected: h2; Actual: h3]\n',
-    'alt-src/linter-test-B.md:28 MD024/no-duplicate-heading/no-duplicate-header Multiple headings with the same content [Context: "### MD001: Heading levels shou..."]\n',
+    'alt-src/linter-test-B.md:17 MD001/heading-increment/header-increment Heading levels should only increment by one level at a time [Expected: h2; Actual: h3]\n',
+    'alt-src/linter-test-B.md:31 MD024/no-duplicate-heading/no-duplicate-header Multiple headings with the same content [Context: "### MD001: Heading levels shou..."]\n',
 
     `Full markdownlint log see in ${path.join(cwd, '.markdownlint_slim.log')}\n`,
 
@@ -873,19 +873,19 @@ test('essential -v', async () => {
 
     'FILE: src/linter-test-A.md\n',
 
-    'src/linter-test-A.md:3 MD001/heading-increment/header-increment Heading levels should only increment by one level at a time [Expected: h2; Actual: h3]\n',
-    'src/linter-test-A.md:7 indented-fence Fenced code shouldn\'t be indented by 1 to 3 spaces [Context: "   ```bash"]\n',
-    'src/linter-test-A.md:11 non-literal-fence-label Invalid language label in fenced code block\n',
-    'src/linter-test-A.md:18 fenced-code-in-quote Fenced code shouldn\'t be in quote\n',
-    'src/linter-test-A.md:26 validate-internal-links Broken link [image does not exist] [Context: "/red-circle.png"]\n',
-    'src/linter-test-A.md:30 validate-internal-links Broken link [file does not exist] [Context: "/another-project/subproject/article"]\n',
-    'src/linter-test-A.md:32 validate-internal-links Broken link [file does not exist] [Context: "/another-project/subproject/article#anchor"]\n',
+    'src/linter-test-A.md:6 MD001/heading-increment/header-increment Heading levels should only increment by one level at a time [Expected: h2; Actual: h3]\n',
+    'src/linter-test-A.md:10 indented-fence Fenced code shouldn\'t be indented by 1 to 3 spaces [Context: "   ```bash"]\n',
+    'src/linter-test-A.md:14 non-literal-fence-label Invalid language label in fenced code block\n',
+    'src/linter-test-A.md:21 fenced-code-in-quote Fenced code shouldn\'t be in quote\n',
+    'src/linter-test-A.md:29 validate-internal-links Broken link [image does not exist] [Context: "/red-circle.png"]\n',
+    'src/linter-test-A.md:33 validate-internal-links Broken link [file does not exist] [Context: "/another-project/subproject/article"]\n',
+    'src/linter-test-A.md:35 validate-internal-links Broken link [file does not exist] [Context: "/another-project/subproject/article#anchor"]\n',
 
     '--------------------------------------------------------------------------------\n',
 
     'FILE: src/subproject/article.md\n',
 
-    'src/subproject/article.md:3 validate-internal-links Broken link [invalid local anchor] [Context: "#anchor"]\n',
+    'src/subproject/article.md:6 validate-internal-links Broken link [invalid local anchor] [Context: "#anchor"]\n',
 
     `Full markdownlint log see in ${path.join(cwd, '.markdownlint_slim.log')}\n`,
 
@@ -921,19 +921,19 @@ test('essential -v -p another-project', async () => {
 
     'FILE: src/linter-test-A.md\n',
 
-    'src/linter-test-A.md:3 MD001/heading-increment/header-increment Heading levels should only increment by one level at a time [Expected: h2; Actual: h3]\n',
-    'src/linter-test-A.md:7 indented-fence Fenced code shouldn\'t be indented by 1 to 3 spaces [Context: "   ```bash"]\n',
-    'src/linter-test-A.md:11 non-literal-fence-label Invalid language label in fenced code block\n',
-    'src/linter-test-A.md:18 fenced-code-in-quote Fenced code shouldn\'t be in quote\n',
-    'src/linter-test-A.md:26 validate-internal-links Broken link [image does not exist] [Context: "/red-circle.png"]\n',
-    'src/linter-test-A.md:32 validate-internal-links Broken link [file exists, but invalid anchor] [Context: "/another-project/subproject/article#anchor"]\n',
-    'src/linter-test-A.md:34 validate-internal-links Broken link [file does not exist] [Context: "/foliant-md-linter/subproject/article"]\n',
+    'src/linter-test-A.md:6 MD001/heading-increment/header-increment Heading levels should only increment by one level at a time [Expected: h2; Actual: h3]\n',
+    'src/linter-test-A.md:10 indented-fence Fenced code shouldn\'t be indented by 1 to 3 spaces [Context: "   ```bash"]\n',
+    'src/linter-test-A.md:14 non-literal-fence-label Invalid language label in fenced code block\n',
+    'src/linter-test-A.md:21 fenced-code-in-quote Fenced code shouldn\'t be in quote\n',
+    'src/linter-test-A.md:29 validate-internal-links Broken link [image does not exist] [Context: "/red-circle.png"]\n',
+    'src/linter-test-A.md:35 validate-internal-links Broken link [file exists, but invalid anchor] [Context: "/another-project/subproject/article#anchor"]\n',
+    'src/linter-test-A.md:37 validate-internal-links Broken link [file does not exist] [Context: "/foliant-md-linter/subproject/article"]\n',
 
     '--------------------------------------------------------------------------------\n',
 
     'FILE: src/subproject/article.md\n',
 
-    'src/subproject/article.md:3 validate-internal-links Broken link [invalid local anchor] [Context: "#anchor"]\n',
+    'src/subproject/article.md:6 validate-internal-links Broken link [invalid local anchor] [Context: "#anchor"]\n',
 
     `Full markdownlint log see in ${path.join(cwd, '.markdownlint_slim.log')}\n`,
 
@@ -969,11 +969,11 @@ test('essential -s alt-src -v', async () => {
 
     'FILE: alt-src/linter-test-B.md\n',
 
-    'alt-src/linter-test-B.md:3 non-literal-fence-label Invalid language label in fenced code block\n',
-    'alt-src/linter-test-B.md:14 MD001/heading-increment/header-increment Heading levels should only increment by one level at a time [Expected: h2; Actual: h3]\n',
-    'alt-src/linter-test-B.md:16 fenced-code-in-quote Fenced code shouldn\'t be in quote\n',
-    'alt-src/linter-test-B.md:20 validate-internal-links Broken link [image does not exist] [Context: "/red-circle.png"]\n',
-    'alt-src/linter-test-B.md:24 indented-fence Fenced code shouldn\'t be indented by 1 to 3 spaces [Context: "   ```bash"]\n',
+    'alt-src/linter-test-B.md:6 non-literal-fence-label Invalid language label in fenced code block\n',
+    'alt-src/linter-test-B.md:17 MD001/heading-increment/header-increment Heading levels should only increment by one level at a time [Expected: h2; Actual: h3]\n',
+    'alt-src/linter-test-B.md:19 fenced-code-in-quote Fenced code shouldn\'t be in quote\n',
+    'alt-src/linter-test-B.md:23 validate-internal-links Broken link [image does not exist] [Context: "/red-circle.png"]\n',
+    'alt-src/linter-test-B.md:27 indented-fence Fenced code shouldn\'t be indented by 1 to 3 spaces [Context: "   ```bash"]\n',
 
     `Full markdownlint log see in ${path.join(cwd, '.markdownlint_slim.log')}\n`,
 
@@ -1003,8 +1003,8 @@ test('essential -s alt-src -v -c', async () => {
 
     'FILE: alt-src/linter-test-B.md\n',
 
-    'alt-src/linter-test-B.md:14 MD001/heading-increment/header-increment Heading levels should only increment by one level at a time [Expected: h2; Actual: h3]\n',
-    'alt-src/linter-test-B.md:28 MD024/no-duplicate-heading/no-duplicate-header Multiple headings with the same content [Context: "### MD001: Heading levels shou..."]\n',
+    'alt-src/linter-test-B.md:17 MD001/heading-increment/header-increment Heading levels should only increment by one level at a time [Expected: h2; Actual: h3]\n',
+    'alt-src/linter-test-B.md:31 MD024/no-duplicate-heading/no-duplicate-header Multiple headings with the same content [Context: "### MD001: Heading levels shou..."]\n',
 
     `Full markdownlint log see in ${path.join(cwd, '.markdownlint_slim.log')}\n`,
 
@@ -1034,8 +1034,8 @@ test('essential -s alt-src -v -c -f', async () => {
 
     'FILE: alt-src/linter-test-B.md\n',
 
-    'alt-src/linter-test-B.md:14 MD001/heading-increment/header-increment Heading levels should only increment by one level at a time [Expected: h2; Actual: h3]\n',
-    'alt-src/linter-test-B.md:28 MD024/no-duplicate-heading/no-duplicate-header Multiple headings with the same content [Context: "### MD001: Heading levels shou..."]\n',
+    'alt-src/linter-test-B.md:17 MD001/heading-increment/header-increment Heading levels should only increment by one level at a time [Expected: h2; Actual: h3]\n',
+    'alt-src/linter-test-B.md:31 MD024/no-duplicate-heading/no-duplicate-header Multiple headings with the same content [Context: "### MD001: Heading levels shou..."]\n',
 
     `Full markdownlint log see in ${path.join(cwd, '.markdownlint_slim.log')}\n`,
 
@@ -1097,19 +1097,19 @@ test('full-check -v', async () => {
 
     'FILE: src/linter-test-A.md\n',
 
-    'src/linter-test-A.md:3 MD001/heading-increment/header-increment Heading levels should only increment by one level at a time [Expected: h2; Actual: h3]\n',
-    'src/linter-test-A.md:7 indented-fence Fenced code shouldn\'t be indented by 1 to 3 spaces [Context: "   ```bash"]\n',
-    'src/linter-test-A.md:11 non-literal-fence-label Invalid language label in fenced code block\n',
-    'src/linter-test-A.md:18 fenced-code-in-quote Fenced code shouldn\'t be in quote\n',
-    'src/linter-test-A.md:26 validate-internal-links Broken link [image does not exist] [Context: "/red-circle.png"]\n',
-    'src/linter-test-A.md:30 validate-internal-links Broken link [file does not exist] [Context: "/another-project/subproject/article"]\n',
-    'src/linter-test-A.md:32 validate-internal-links Broken link [file does not exist] [Context: "/another-project/subproject/article#anchor"]\n',
+    'src/linter-test-A.md:6 MD001/heading-increment/header-increment Heading levels should only increment by one level at a time [Expected: h2; Actual: h3]\n',
+    'src/linter-test-A.md:10 indented-fence Fenced code shouldn\'t be indented by 1 to 3 spaces [Context: "   ```bash"]\n',
+    'src/linter-test-A.md:14 non-literal-fence-label Invalid language label in fenced code block\n',
+    'src/linter-test-A.md:21 fenced-code-in-quote Fenced code shouldn\'t be in quote\n',
+    'src/linter-test-A.md:29 validate-internal-links Broken link [image does not exist] [Context: "/red-circle.png"]\n',
+    'src/linter-test-A.md:33 validate-internal-links Broken link [file does not exist] [Context: "/another-project/subproject/article"]\n',
+    'src/linter-test-A.md:35 validate-internal-links Broken link [file does not exist] [Context: "/another-project/subproject/article#anchor"]\n',
 
     '--------------------------------------------------------------------------------\n',
 
     'FILE: src/subproject/article.md\n',
 
-    'src/subproject/article.md:3 validate-internal-links Broken link [invalid local anchor] [Context: "#anchor"]\n',
+    'src/subproject/article.md:6 validate-internal-links Broken link [invalid local anchor] [Context: "#anchor"]\n',
 
     `Full markdownlint log see in ${path.join(cwd, '.markdownlint_slim.log')}\n`,
 
@@ -1147,19 +1147,19 @@ test('full-check -v -p another-project', async () => {
 
     'FILE: src/linter-test-A.md\n',
 
-    'src/linter-test-A.md:3 MD001/heading-increment/header-increment Heading levels should only increment by one level at a time [Expected: h2; Actual: h3]\n',
-    'src/linter-test-A.md:7 indented-fence Fenced code shouldn\'t be indented by 1 to 3 spaces [Context: "   ```bash"]\n',
-    'src/linter-test-A.md:11 non-literal-fence-label Invalid language label in fenced code block\n',
-    'src/linter-test-A.md:18 fenced-code-in-quote Fenced code shouldn\'t be in quote\n',
-    'src/linter-test-A.md:26 validate-internal-links Broken link [image does not exist] [Context: "/red-circle.png"]\n',
-    'src/linter-test-A.md:32 validate-internal-links Broken link [file exists, but invalid anchor] [Context: "/another-project/subproject/article#anchor"]\n',
-    'src/linter-test-A.md:34 validate-internal-links Broken link [file does not exist] [Context: "/foliant-md-linter/subproject/article"]\n',
+    'src/linter-test-A.md:6 MD001/heading-increment/header-increment Heading levels should only increment by one level at a time [Expected: h2; Actual: h3]\n',
+    'src/linter-test-A.md:10 indented-fence Fenced code shouldn\'t be indented by 1 to 3 spaces [Context: "   ```bash"]\n',
+    'src/linter-test-A.md:14 non-literal-fence-label Invalid language label in fenced code block\n',
+    'src/linter-test-A.md:21 fenced-code-in-quote Fenced code shouldn\'t be in quote\n',
+    'src/linter-test-A.md:29 validate-internal-links Broken link [image does not exist] [Context: "/red-circle.png"]\n',
+    'src/linter-test-A.md:35 validate-internal-links Broken link [file exists, but invalid anchor] [Context: "/another-project/subproject/article#anchor"]\n',
+    'src/linter-test-A.md:37 validate-internal-links Broken link [file does not exist] [Context: "/foliant-md-linter/subproject/article"]\n',
 
     '--------------------------------------------------------------------------------\n',
 
     'FILE: src/subproject/article.md\n',
 
-    'src/subproject/article.md:3 validate-internal-links Broken link [invalid local anchor] [Context: "#anchor"]\n',
+    'src/subproject/article.md:6 validate-internal-links Broken link [invalid local anchor] [Context: "#anchor"]\n',
 
     `Full markdownlint log see in ${path.join(cwd, '.markdownlint_slim.log')}\n`,
 
@@ -1197,11 +1197,11 @@ test('full-check -s alt-src -v', async () => {
 
     'FILE: alt-src/linter-test-B.md\n',
 
-    'alt-src/linter-test-B.md:3 non-literal-fence-label Invalid language label in fenced code block\n',
-    'alt-src/linter-test-B.md:14 MD001/heading-increment/header-increment Heading levels should only increment by one level at a time [Expected: h2; Actual: h3]\n',
-    'alt-src/linter-test-B.md:16 fenced-code-in-quote Fenced code shouldn\'t be in quote\n',
-    'alt-src/linter-test-B.md:20 validate-internal-links Broken link [image does not exist] [Context: "/red-circle.png"]\n',
-    'alt-src/linter-test-B.md:24 indented-fence Fenced code shouldn\'t be indented by 1 to 3 spaces [Context: "   ```bash"]\n',
+    'alt-src/linter-test-B.md:6 non-literal-fence-label Invalid language label in fenced code block\n',
+    'alt-src/linter-test-B.md:17 MD001/heading-increment/header-increment Heading levels should only increment by one level at a time [Expected: h2; Actual: h3]\n',
+    'alt-src/linter-test-B.md:19 fenced-code-in-quote Fenced code shouldn\'t be in quote\n',
+    'alt-src/linter-test-B.md:23 validate-internal-links Broken link [image does not exist] [Context: "/red-circle.png"]\n',
+    'alt-src/linter-test-B.md:27 indented-fence Fenced code shouldn\'t be indented by 1 to 3 spaces [Context: "   ```bash"]\n',
 
     `Full markdownlint log see in ${path.join(cwd, '.markdownlint_slim.log')}\n`,
 
@@ -1233,8 +1233,8 @@ test('full-check -s alt-src -v -c', async () => {
 
     'FILE: alt-src/linter-test-B.md\n',
 
-    'alt-src/linter-test-B.md:14 MD001/heading-increment/header-increment Heading levels should only increment by one level at a time [Expected: h2; Actual: h3]\n',
-    'alt-src/linter-test-B.md:28 MD024/no-duplicate-heading/no-duplicate-header Multiple headings with the same content [Context: "### MD001: Heading levels shou..."]\n',
+    'alt-src/linter-test-B.md:17 MD001/heading-increment/header-increment Heading levels should only increment by one level at a time [Expected: h2; Actual: h3]\n',
+    'alt-src/linter-test-B.md:31 MD024/no-duplicate-heading/no-duplicate-header Multiple headings with the same content [Context: "### MD001: Heading levels shou..."]\n',
 
     `Full markdownlint log see in ${path.join(cwd, '.markdownlint_slim.log')}\n`,
 
@@ -1267,8 +1267,8 @@ test('full-check -s alt-src -v -c -l', async () => {
 
     'FILE: alt-src/linter-test-B.md\n',
 
-    'alt-src/linter-test-B.md:14 MD001/heading-increment/header-increment Heading levels should only increment by one level at a time [Expected: h2; Actual: h3]\n',
-    'alt-src/linter-test-B.md:28 MD024/no-duplicate-heading/no-duplicate-header Multiple headings with the same content [Context: "### MD001: Heading levels shou..."]\n',
+    'alt-src/linter-test-B.md:17 MD001/heading-increment/header-increment Heading levels should only increment by one level at a time [Expected: h2; Actual: h3]\n',
+    'alt-src/linter-test-B.md:31 MD024/no-duplicate-heading/no-duplicate-header Multiple headings with the same content [Context: "### MD001: Heading levels shou..."]\n',
 
     `Full markdownlint log see in ${path.join(cwd, '.markdownlint_slim.log')}\n`,
 
@@ -1304,8 +1304,8 @@ test('full-check -s alt-src -v -c -f', async () => {
 
     'FILE: alt-src/linter-test-B.md\n',
 
-    'alt-src/linter-test-B.md:14 MD001/heading-increment/header-increment Heading levels should only increment by one level at a time [Expected: h2; Actual: h3]\n',
-    'alt-src/linter-test-B.md:28 MD024/no-duplicate-heading/no-duplicate-header Multiple headings with the same content [Context: "### MD001: Heading levels shou..."]\n',
+    'alt-src/linter-test-B.md:17 MD001/heading-increment/header-increment Heading levels should only increment by one level at a time [Expected: h2; Actual: h3]\n',
+    'alt-src/linter-test-B.md:31 MD024/no-duplicate-heading/no-duplicate-header Multiple headings with the same content [Context: "### MD001: Heading levels shou..."]\n',
 
     `Full markdownlint log see in ${path.join(cwd, '.markdownlint_slim.log')}\n`,
 
@@ -1349,8 +1349,8 @@ test('print -v', async () => {
     'Checked 1 files\n',
     'Found 2 critical formatting errors\n',
     'FILE: alt-src/linter-test-B.md\n',
-    'alt-src/linter-test-B.md:14 MD001/heading-increment/header-increment Heading levels should only increment by one level at a time [Expected: h2; Actual: h3]\n',
-    'alt-src/linter-test-B.md:28 MD024/no-duplicate-heading/no-duplicate-header Multiple headings with the same content [Context: "### MD001: Heading levels shou..."]\n',
+    'alt-src/linter-test-B.md:17 MD001/heading-increment/header-increment Heading levels should only increment by one level at a time [Expected: h2; Actual: h3]\n',
+    'alt-src/linter-test-B.md:31 MD024/no-duplicate-heading/no-duplicate-header Multiple headings with the same content [Context: "### MD001: Heading levels shou..."]\n',
     `Full markdownlint log see in ${path.join(cwd, '.markdownlint_slim.log')}\n`,
     'Found 2 styleguide and formatting errors\n',
     `Full markdownlint log see in ${path.join(cwd, '.markdownlint_full.log')}\n`,

--- a/test/linter.spec.js
+++ b/test/linter.spec.js
@@ -137,19 +137,19 @@ test('slim -v', async () => {
 
     'FILE: src/linter-test-A.md\n',
 
-    'src/linter-test-A.md:6 MD001/heading-increment/header-increment Heading levels should only increment by one level at a time [Expected: h2; Actual: h3]\n',
-    'src/linter-test-A.md:10 indented-fence Fenced code shouldn\'t be indented by 1 to 3 spaces [Context: "   ```bash"]\n',
-    'src/linter-test-A.md:14 non-literal-fence-label Invalid language label in fenced code block\n',
-    'src/linter-test-A.md:21 fenced-code-in-quote Fenced code shouldn\'t be in quote\n',
-    'src/linter-test-A.md:29 validate-internal-links Broken link [image does not exist] [Context: "/red-circle.png"]\n',
-    'src/linter-test-A.md:33 validate-internal-links Broken link [file does not exist] [Context: "/another-project/subproject/article"]\n',
-    'src/linter-test-A.md:35 validate-internal-links Broken link [file does not exist] [Context: "/another-project/subproject/article#anchor"]\n',
+    'src/linter-test-A.md:8 MD001/heading-increment/header-increment Heading levels should only increment by one level at a time [Expected: h2; Actual: h3]\n',
+    'src/linter-test-A.md:12 indented-fence Fenced code shouldn\'t be indented by 1 to 3 spaces [Context: "   ```bash"]\n',
+    'src/linter-test-A.md:16 non-literal-fence-label Invalid language label in fenced code block\n',
+    'src/linter-test-A.md:23 fenced-code-in-quote Fenced code shouldn\'t be in quote\n',
+    'src/linter-test-A.md:31 validate-internal-links Broken link [image does not exist] [Context: "/red-circle.png"]\n',
+    'src/linter-test-A.md:35 validate-internal-links Broken link [file does not exist] [Context: "/another-project/subproject/article"]\n',
+    'src/linter-test-A.md:37 validate-internal-links Broken link [file does not exist] [Context: "/another-project/subproject/article#anchor"]\n',
 
     '--------------------------------------------------------------------------------\n',
 
     'FILE: src/subproject/article.md\n',
 
-    'src/subproject/article.md:6 validate-internal-links Broken link [invalid local anchor] [Context: "#anchor"]\n',
+    'src/subproject/article.md:8 validate-internal-links Broken link [invalid local anchor] [Context: "#anchor"]\n',
 
     `Full markdownlint log see in ${path.join(cwd, '.markdownlint_slim.log')}\n`]
   const result = await cli(['slim', '-v'], '.')
@@ -169,11 +169,11 @@ test('slim -v -s alt-src', async () => {
 
     'FILE: alt-src/linter-test-B.md\n',
 
-    'alt-src/linter-test-B.md:6 non-literal-fence-label Invalid language label in fenced code block\n',
-    'alt-src/linter-test-B.md:17 MD001/heading-increment/header-increment Heading levels should only increment by one level at a time [Expected: h2; Actual: h3]\n',
-    'alt-src/linter-test-B.md:19 fenced-code-in-quote Fenced code shouldn\'t be in quote\n',
-    'alt-src/linter-test-B.md:23 validate-internal-links Broken link [image does not exist] [Context: "/red-circle.png"]\n',
-    'alt-src/linter-test-B.md:27 indented-fence Fenced code shouldn\'t be indented by 1 to 3 spaces [Context: "   ```bash"]\n',
+    'alt-src/linter-test-B.md:8 non-literal-fence-label Invalid language label in fenced code block\n',
+    'alt-src/linter-test-B.md:19 MD001/heading-increment/header-increment Heading levels should only increment by one level at a time [Expected: h2; Actual: h3]\n',
+    'alt-src/linter-test-B.md:21 fenced-code-in-quote Fenced code shouldn\'t be in quote\n',
+    'alt-src/linter-test-B.md:25 validate-internal-links Broken link [image does not exist] [Context: "/red-circle.png"]\n',
+    'alt-src/linter-test-B.md:29 indented-fence Fenced code shouldn\'t be indented by 1 to 3 spaces [Context: "   ```bash"]\n',
 
     `Full markdownlint log see in ${path.join(cwd, '.markdownlint_slim.log')}\n`]
   const result = await cli(['slim', '-v', '-s alt-src'], '.')
@@ -193,19 +193,19 @@ test('slim -v -p another-project', async () => {
 
     'FILE: src/linter-test-A.md\n',
 
-    'src/linter-test-A.md:6 MD001/heading-increment/header-increment Heading levels should only increment by one level at a time [Expected: h2; Actual: h3]\n',
-    'src/linter-test-A.md:10 indented-fence Fenced code shouldn\'t be indented by 1 to 3 spaces [Context: "   ```bash"]\n',
-    'src/linter-test-A.md:14 non-literal-fence-label Invalid language label in fenced code block\n',
-    'src/linter-test-A.md:21 fenced-code-in-quote Fenced code shouldn\'t be in quote\n',
-    'src/linter-test-A.md:29 validate-internal-links Broken link [image does not exist] [Context: "/red-circle.png"]\n',
-    'src/linter-test-A.md:35 validate-internal-links Broken link [file exists, but invalid anchor] [Context: "/another-project/subproject/article#anchor"]\n',
-    'src/linter-test-A.md:37 validate-internal-links Broken link [file does not exist] [Context: "/foliant-md-linter/subproject/article"]\n',
+    'src/linter-test-A.md:8 MD001/heading-increment/header-increment Heading levels should only increment by one level at a time [Expected: h2; Actual: h3]\n',
+    'src/linter-test-A.md:12 indented-fence Fenced code shouldn\'t be indented by 1 to 3 spaces [Context: "   ```bash"]\n',
+    'src/linter-test-A.md:16 non-literal-fence-label Invalid language label in fenced code block\n',
+    'src/linter-test-A.md:23 fenced-code-in-quote Fenced code shouldn\'t be in quote\n',
+    'src/linter-test-A.md:31 validate-internal-links Broken link [image does not exist] [Context: "/red-circle.png"]\n',
+    'src/linter-test-A.md:37 validate-internal-links Broken link [file exists, but invalid anchor] [Context: "/another-project/subproject/article#anchor"]\n',
+    'src/linter-test-A.md:39 validate-internal-links Broken link [file does not exist] [Context: "/foliant-md-linter/subproject/article"]\n',
 
     '--------------------------------------------------------------------------------\n',
 
     'FILE: src/subproject/article.md\n',
 
-    'src/subproject/article.md:6 validate-internal-links Broken link [invalid local anchor] [Context: "#anchor"]\n',
+    'src/subproject/article.md:8 validate-internal-links Broken link [invalid local anchor] [Context: "#anchor"]\n',
 
     `Full markdownlint log see in ${path.join(cwd, '.markdownlint_slim.log')}\n`]
   const result = await cli(['slim', '-v', '-p another-project'], '.')
@@ -225,19 +225,19 @@ test('slim -v -p another-project -f', async () => {
 
     'FILE: src/linter-test-A.md\n',
 
-    'src/linter-test-A.md:6 MD001/heading-increment/header-increment Heading levels should only increment by one level at a time [Expected: h2; Actual: h3]\n',
-    'src/linter-test-A.md:10 indented-fence Fenced code shouldn\'t be indented by 1 to 3 spaces [Context: "   ```bash"]\n',
-    'src/linter-test-A.md:14 non-literal-fence-label Invalid language label in fenced code block\n',
-    'src/linter-test-A.md:21 fenced-code-in-quote Fenced code shouldn\'t be in quote\n',
-    'src/linter-test-A.md:29 validate-internal-links Broken link [image does not exist] [Context: "/red-circle.png"]\n',
-    'src/linter-test-A.md:35 validate-internal-links Broken link [file exists, but invalid anchor] [Context: "/another-project/subproject/article#anchor"]\n',
-    'src/linter-test-A.md:37 validate-internal-links Broken link [file does not exist] [Context: "/foliant-md-linter/subproject/article"]\n',
+    'src/linter-test-A.md:8 MD001/heading-increment/header-increment Heading levels should only increment by one level at a time [Expected: h2; Actual: h3]\n',
+    'src/linter-test-A.md:12 indented-fence Fenced code shouldn\'t be indented by 1 to 3 spaces [Context: "   ```bash"]\n',
+    'src/linter-test-A.md:16 non-literal-fence-label Invalid language label in fenced code block\n',
+    'src/linter-test-A.md:23 fenced-code-in-quote Fenced code shouldn\'t be in quote\n',
+    'src/linter-test-A.md:31 validate-internal-links Broken link [image does not exist] [Context: "/red-circle.png"]\n',
+    'src/linter-test-A.md:37 validate-internal-links Broken link [file exists, but invalid anchor] [Context: "/another-project/subproject/article#anchor"]\n',
+    'src/linter-test-A.md:39 validate-internal-links Broken link [file does not exist] [Context: "/foliant-md-linter/subproject/article"]\n',
 
     '--------------------------------------------------------------------------------\n',
 
     'FILE: src/subproject/article.md\n',
 
-    'src/subproject/article.md:6 validate-internal-links Broken link [invalid local anchor] [Context: "#anchor"]\n',
+    'src/subproject/article.md:8 validate-internal-links Broken link [invalid local anchor] [Context: "#anchor"]\n',
 
     `Full markdownlint log see in ${path.join(cwd, '.markdownlint_slim.log')}\n`]
   const result = await cli(['slim', '-v', '-p another-project', '-f'], '.')
@@ -303,19 +303,19 @@ test('styleguide -v', async () => {
 
     'FILE: src/linter-test-A.md\n',
 
-    'src/linter-test-A.md:6 MD001/heading-increment/header-increment Heading levels should only increment by one level at a time [Expected: h2; Actual: h3]\n',
-    'src/linter-test-A.md:10 indented-fence Fenced code shouldn\'t be indented by 1 to 3 spaces [Context: "   ```bash"]\n',
-    'src/linter-test-A.md:14 non-literal-fence-label Invalid language label in fenced code block\n',
-    'src/linter-test-A.md:21 fenced-code-in-quote Fenced code shouldn\'t be in quote\n',
-    'src/linter-test-A.md:29 validate-internal-links Broken link [image does not exist] [Context: "/red-circle.png"]\n',
-    'src/linter-test-A.md:33 validate-internal-links Broken link [file does not exist] [Context: "/another-project/subproject/article"]\n',
-    'src/linter-test-A.md:35 validate-internal-links Broken link [file does not exist] [Context: "/another-project/subproject/article#anchor"]\n',
+    'src/linter-test-A.md:8 MD001/heading-increment/header-increment Heading levels should only increment by one level at a time [Expected: h2; Actual: h3]\n',
+    'src/linter-test-A.md:12 indented-fence Fenced code shouldn\'t be indented by 1 to 3 spaces [Context: "   ```bash"]\n',
+    'src/linter-test-A.md:16 non-literal-fence-label Invalid language label in fenced code block\n',
+    'src/linter-test-A.md:23 fenced-code-in-quote Fenced code shouldn\'t be in quote\n',
+    'src/linter-test-A.md:31 validate-internal-links Broken link [image does not exist] [Context: "/red-circle.png"]\n',
+    'src/linter-test-A.md:35 validate-internal-links Broken link [file does not exist] [Context: "/another-project/subproject/article"]\n',
+    'src/linter-test-A.md:37 validate-internal-links Broken link [file does not exist] [Context: "/another-project/subproject/article#anchor"]\n',
 
     '--------------------------------------------------------------------------------\n',
 
     'FILE: src/subproject/article.md\n',
 
-    'src/subproject/article.md:6 validate-internal-links Broken link [invalid local anchor] [Context: "#anchor"]\n',
+    'src/subproject/article.md:8 validate-internal-links Broken link [invalid local anchor] [Context: "#anchor"]\n',
 
     `Full markdownlint log see in ${path.join(cwd, '.markdownlint_slim.log')}\n`,
 
@@ -338,19 +338,19 @@ test('styleguide -v -p another-project', async () => {
 
     'FILE: src/linter-test-A.md\n',
 
-    'src/linter-test-A.md:6 MD001/heading-increment/header-increment Heading levels should only increment by one level at a time [Expected: h2; Actual: h3]\n',
-    'src/linter-test-A.md:10 indented-fence Fenced code shouldn\'t be indented by 1 to 3 spaces [Context: "   ```bash"]\n',
-    'src/linter-test-A.md:14 non-literal-fence-label Invalid language label in fenced code block\n',
-    'src/linter-test-A.md:21 fenced-code-in-quote Fenced code shouldn\'t be in quote\n',
-    'src/linter-test-A.md:29 validate-internal-links Broken link [image does not exist] [Context: "/red-circle.png"]\n',
-    'src/linter-test-A.md:35 validate-internal-links Broken link [file exists, but invalid anchor] [Context: "/another-project/subproject/article#anchor"]\n',
-    'src/linter-test-A.md:37 validate-internal-links Broken link [file does not exist] [Context: "/foliant-md-linter/subproject/article"]\n',
+    'src/linter-test-A.md:8 MD001/heading-increment/header-increment Heading levels should only increment by one level at a time [Expected: h2; Actual: h3]\n',
+    'src/linter-test-A.md:12 indented-fence Fenced code shouldn\'t be indented by 1 to 3 spaces [Context: "   ```bash"]\n',
+    'src/linter-test-A.md:16 non-literal-fence-label Invalid language label in fenced code block\n',
+    'src/linter-test-A.md:23 fenced-code-in-quote Fenced code shouldn\'t be in quote\n',
+    'src/linter-test-A.md:31 validate-internal-links Broken link [image does not exist] [Context: "/red-circle.png"]\n',
+    'src/linter-test-A.md:37 validate-internal-links Broken link [file exists, but invalid anchor] [Context: "/another-project/subproject/article#anchor"]\n',
+    'src/linter-test-A.md:39 validate-internal-links Broken link [file does not exist] [Context: "/foliant-md-linter/subproject/article"]\n',
 
     '--------------------------------------------------------------------------------\n',
 
     'FILE: src/subproject/article.md\n',
 
-    'src/subproject/article.md:6 validate-internal-links Broken link [invalid local anchor] [Context: "#anchor"]\n',
+    'src/subproject/article.md:8 validate-internal-links Broken link [invalid local anchor] [Context: "#anchor"]\n',
 
     `Full markdownlint log see in ${path.join(cwd, '.markdownlint_slim.log')}\n`,
 
@@ -373,11 +373,11 @@ test('styleguide -s alt-src -v', async () => {
 
     'FILE: alt-src/linter-test-B.md\n',
 
-    'alt-src/linter-test-B.md:6 non-literal-fence-label Invalid language label in fenced code block\n',
-    'alt-src/linter-test-B.md:17 MD001/heading-increment/header-increment Heading levels should only increment by one level at a time [Expected: h2; Actual: h3]\n',
-    'alt-src/linter-test-B.md:19 fenced-code-in-quote Fenced code shouldn\'t be in quote\n',
-    'alt-src/linter-test-B.md:23 validate-internal-links Broken link [image does not exist] [Context: "/red-circle.png"]\n',
-    'alt-src/linter-test-B.md:27 indented-fence Fenced code shouldn\'t be indented by 1 to 3 spaces [Context: "   ```bash"]\n',
+    'alt-src/linter-test-B.md:8 non-literal-fence-label Invalid language label in fenced code block\n',
+    'alt-src/linter-test-B.md:19 MD001/heading-increment/header-increment Heading levels should only increment by one level at a time [Expected: h2; Actual: h3]\n',
+    'alt-src/linter-test-B.md:21 fenced-code-in-quote Fenced code shouldn\'t be in quote\n',
+    'alt-src/linter-test-B.md:25 validate-internal-links Broken link [image does not exist] [Context: "/red-circle.png"]\n',
+    'alt-src/linter-test-B.md:29 indented-fence Fenced code shouldn\'t be indented by 1 to 3 spaces [Context: "   ```bash"]\n',
 
     `Full markdownlint log see in ${path.join(cwd, '.markdownlint_slim.log')}\n`,
 
@@ -400,8 +400,8 @@ test('styleguide -s alt-src -v -c', async () => {
 
     'FILE: alt-src/linter-test-B.md\n',
 
-    'alt-src/linter-test-B.md:17 MD001/heading-increment/header-increment Heading levels should only increment by one level at a time [Expected: h2; Actual: h3]\n',
-    'alt-src/linter-test-B.md:31 MD024/no-duplicate-heading/no-duplicate-header Multiple headings with the same content [Context: "### MD001: Heading levels shou..."]\n',
+    'alt-src/linter-test-B.md:19 MD001/heading-increment/header-increment Heading levels should only increment by one level at a time [Expected: h2; Actual: h3]\n',
+    'alt-src/linter-test-B.md:33 MD024/no-duplicate-heading/no-duplicate-header Multiple headings with the same content [Context: "### MD001: Heading levels shou..."]\n',
 
     `Full markdownlint log see in ${path.join(cwd, '.markdownlint_slim.log')}\n`,
 
@@ -424,8 +424,8 @@ test('styleguide -s alt-src -v -c -f', async () => {
 
     'FILE: alt-src/linter-test-B.md\n',
 
-    'alt-src/linter-test-B.md:17 MD001/heading-increment/header-increment Heading levels should only increment by one level at a time [Expected: h2; Actual: h3]\n',
-    'alt-src/linter-test-B.md:31 MD024/no-duplicate-heading/no-duplicate-header Multiple headings with the same content [Context: "### MD001: Heading levels shou..."]\n',
+    'alt-src/linter-test-B.md:19 MD001/heading-increment/header-increment Heading levels should only increment by one level at a time [Expected: h2; Actual: h3]\n',
+    'alt-src/linter-test-B.md:33 MD024/no-duplicate-heading/no-duplicate-header Multiple headings with the same content [Context: "### MD001: Heading levels shou..."]\n',
 
     `Full markdownlint log see in ${path.join(cwd, '.markdownlint_slim.log')}\n`,
 
@@ -494,19 +494,19 @@ test('fix -v', async () => {
 
     'FILE: src/linter-test-A.md\n',
 
-    'src/linter-test-A.md:6 MD001/heading-increment/header-increment Heading levels should only increment by one level at a time [Expected: h2; Actual: h3]\n',
-    'src/linter-test-A.md:10 indented-fence Fenced code shouldn\'t be indented by 1 to 3 spaces [Context: "   ```bash"]\n',
-    'src/linter-test-A.md:14 non-literal-fence-label Invalid language label in fenced code block\n',
-    'src/linter-test-A.md:21 fenced-code-in-quote Fenced code shouldn\'t be in quote\n',
-    'src/linter-test-A.md:29 validate-internal-links Broken link [image does not exist] [Context: "/red-circle.png"]\n',
-    'src/linter-test-A.md:33 validate-internal-links Broken link [file does not exist] [Context: "/another-project/subproject/article"]\n',
-    'src/linter-test-A.md:35 validate-internal-links Broken link [file does not exist] [Context: "/another-project/subproject/article#anchor"]\n',
+    'src/linter-test-A.md:8 MD001/heading-increment/header-increment Heading levels should only increment by one level at a time [Expected: h2; Actual: h3]\n',
+    'src/linter-test-A.md:12 indented-fence Fenced code shouldn\'t be indented by 1 to 3 spaces [Context: "   ```bash"]\n',
+    'src/linter-test-A.md:16 non-literal-fence-label Invalid language label in fenced code block\n',
+    'src/linter-test-A.md:23 fenced-code-in-quote Fenced code shouldn\'t be in quote\n',
+    'src/linter-test-A.md:31 validate-internal-links Broken link [image does not exist] [Context: "/red-circle.png"]\n',
+    'src/linter-test-A.md:35 validate-internal-links Broken link [file does not exist] [Context: "/another-project/subproject/article"]\n',
+    'src/linter-test-A.md:37 validate-internal-links Broken link [file does not exist] [Context: "/another-project/subproject/article#anchor"]\n',
 
     '--------------------------------------------------------------------------------\n',
 
     'FILE: src/subproject/article.md\n',
 
-    'src/subproject/article.md:6 validate-internal-links Broken link [invalid local anchor] [Context: "#anchor"]\n',
+    'src/subproject/article.md:8 validate-internal-links Broken link [invalid local anchor] [Context: "#anchor"]\n',
 
     `Full markdownlint log see in ${path.join(cwd, '.markdownlint_slim.log')}\n`,
 
@@ -529,19 +529,19 @@ test('fix -v -p another-project', async () => {
 
     'FILE: src/linter-test-A.md\n',
 
-    'src/linter-test-A.md:6 MD001/heading-increment/header-increment Heading levels should only increment by one level at a time [Expected: h2; Actual: h3]\n',
-    'src/linter-test-A.md:10 indented-fence Fenced code shouldn\'t be indented by 1 to 3 spaces [Context: "   ```bash"]\n',
-    'src/linter-test-A.md:14 non-literal-fence-label Invalid language label in fenced code block\n',
-    'src/linter-test-A.md:21 fenced-code-in-quote Fenced code shouldn\'t be in quote\n',
-    'src/linter-test-A.md:29 validate-internal-links Broken link [image does not exist] [Context: "/red-circle.png"]\n',
-    'src/linter-test-A.md:35 validate-internal-links Broken link [file exists, but invalid anchor] [Context: "/another-project/subproject/article#anchor"]\n',
-    'src/linter-test-A.md:37 validate-internal-links Broken link [file does not exist] [Context: "/foliant-md-linter/subproject/article"]\n',
+    'src/linter-test-A.md:8 MD001/heading-increment/header-increment Heading levels should only increment by one level at a time [Expected: h2; Actual: h3]\n',
+    'src/linter-test-A.md:12 indented-fence Fenced code shouldn\'t be indented by 1 to 3 spaces [Context: "   ```bash"]\n',
+    'src/linter-test-A.md:16 non-literal-fence-label Invalid language label in fenced code block\n',
+    'src/linter-test-A.md:23 fenced-code-in-quote Fenced code shouldn\'t be in quote\n',
+    'src/linter-test-A.md:31 validate-internal-links Broken link [image does not exist] [Context: "/red-circle.png"]\n',
+    'src/linter-test-A.md:37 validate-internal-links Broken link [file exists, but invalid anchor] [Context: "/another-project/subproject/article#anchor"]\n',
+    'src/linter-test-A.md:39 validate-internal-links Broken link [file does not exist] [Context: "/foliant-md-linter/subproject/article"]\n',
 
     '--------------------------------------------------------------------------------\n',
 
     'FILE: src/subproject/article.md\n',
 
-    'src/subproject/article.md:6 validate-internal-links Broken link [invalid local anchor] [Context: "#anchor"]\n',
+    'src/subproject/article.md:8 validate-internal-links Broken link [invalid local anchor] [Context: "#anchor"]\n',
 
     `Full markdownlint log see in ${path.join(cwd, '.markdownlint_slim.log')}\n`,
 
@@ -564,10 +564,10 @@ test('fix -v -c', async () => {
 
     'FILE: src/linter-test-A.md\n',
 
-    'src/linter-test-A.md:6 MD001/heading-increment/header-increment Heading levels should only increment by one level at a time [Expected: h2; Actual: h3]\n',
-    'src/linter-test-A.md:8 MD024/no-duplicate-heading/no-duplicate-header Multiple headings with the same content [Context: "### MD001: Heading levels shou..."]\n',
+    'src/linter-test-A.md:8 MD001/heading-increment/header-increment Heading levels should only increment by one level at a time [Expected: h2; Actual: h3]\n',
+    'src/linter-test-A.md:10 MD024/no-duplicate-heading/no-duplicate-header Multiple headings with the same content [Context: "### MD001: Heading levels shou..."]\n',
     'FILE: src/subproject/article.md\n',
-    'src/subproject/article.md:6:1 MD051/link-fragments Link fragments should be valid [Context: "[broken local link](#anchor)"]\n',
+    'src/subproject/article.md:8:1 MD051/link-fragments Link fragments should be valid [Context: "[broken local link](#anchor)"]\n',
 
     `Full markdownlint log see in ${path.join(cwd, '.markdownlint_slim.log')}\n`,
 
@@ -590,8 +590,8 @@ test('fix -v -c -s alt-src', async () => {
 
     'FILE: alt-src/linter-test-B.md\n',
 
-    'alt-src/linter-test-B.md:17 MD001/heading-increment/header-increment Heading levels should only increment by one level at a time [Expected: h2; Actual: h3]\n',
-    'alt-src/linter-test-B.md:31 MD024/no-duplicate-heading/no-duplicate-header Multiple headings with the same content [Context: "### MD001: Heading levels shou..."]\n',
+    'alt-src/linter-test-B.md:19 MD001/heading-increment/header-increment Heading levels should only increment by one level at a time [Expected: h2; Actual: h3]\n',
+    'alt-src/linter-test-B.md:33 MD024/no-duplicate-heading/no-duplicate-header Multiple headings with the same content [Context: "### MD001: Heading levels shou..."]\n',
 
     `Full markdownlint log see in ${path.join(cwd, '.markdownlint_slim.log')}\n`,
 
@@ -614,8 +614,8 @@ test('fix -v -c -s alt-src -f', async () => {
 
     'FILE: alt-src/linter-test-B.md\n',
 
-    'alt-src/linter-test-B.md:17 MD001/heading-increment/header-increment Heading levels should only increment by one level at a time [Expected: h2; Actual: h3]\n',
-    'alt-src/linter-test-B.md:31 MD024/no-duplicate-heading/no-duplicate-header Multiple headings with the same content [Context: "### MD001: Heading levels shou..."]\n',
+    'alt-src/linter-test-B.md:19 MD001/heading-increment/header-increment Heading levels should only increment by one level at a time [Expected: h2; Actual: h3]\n',
+    'alt-src/linter-test-B.md:33 MD024/no-duplicate-heading/no-duplicate-header Multiple headings with the same content [Context: "### MD001: Heading levels shou..."]\n',
 
     `Full markdownlint log see in ${path.join(cwd, '.markdownlint_slim.log')}\n`,
 
@@ -873,19 +873,19 @@ test('essential -v', async () => {
 
     'FILE: src/linter-test-A.md\n',
 
-    'src/linter-test-A.md:6 MD001/heading-increment/header-increment Heading levels should only increment by one level at a time [Expected: h2; Actual: h3]\n',
-    'src/linter-test-A.md:10 indented-fence Fenced code shouldn\'t be indented by 1 to 3 spaces [Context: "   ```bash"]\n',
-    'src/linter-test-A.md:14 non-literal-fence-label Invalid language label in fenced code block\n',
-    'src/linter-test-A.md:21 fenced-code-in-quote Fenced code shouldn\'t be in quote\n',
-    'src/linter-test-A.md:29 validate-internal-links Broken link [image does not exist] [Context: "/red-circle.png"]\n',
-    'src/linter-test-A.md:33 validate-internal-links Broken link [file does not exist] [Context: "/another-project/subproject/article"]\n',
-    'src/linter-test-A.md:35 validate-internal-links Broken link [file does not exist] [Context: "/another-project/subproject/article#anchor"]\n',
+    'src/linter-test-A.md:8 MD001/heading-increment/header-increment Heading levels should only increment by one level at a time [Expected: h2; Actual: h3]\n',
+    'src/linter-test-A.md:12 indented-fence Fenced code shouldn\'t be indented by 1 to 3 spaces [Context: "   ```bash"]\n',
+    'src/linter-test-A.md:16 non-literal-fence-label Invalid language label in fenced code block\n',
+    'src/linter-test-A.md:23 fenced-code-in-quote Fenced code shouldn\'t be in quote\n',
+    'src/linter-test-A.md:31 validate-internal-links Broken link [image does not exist] [Context: "/red-circle.png"]\n',
+    'src/linter-test-A.md:35 validate-internal-links Broken link [file does not exist] [Context: "/another-project/subproject/article"]\n',
+    'src/linter-test-A.md:37 validate-internal-links Broken link [file does not exist] [Context: "/another-project/subproject/article#anchor"]\n',
 
     '--------------------------------------------------------------------------------\n',
 
     'FILE: src/subproject/article.md\n',
 
-    'src/subproject/article.md:6 validate-internal-links Broken link [invalid local anchor] [Context: "#anchor"]\n',
+    'src/subproject/article.md:8 validate-internal-links Broken link [invalid local anchor] [Context: "#anchor"]\n',
 
     `Full markdownlint log see in ${path.join(cwd, '.markdownlint_slim.log')}\n`,
 
@@ -921,19 +921,19 @@ test('essential -v -p another-project', async () => {
 
     'FILE: src/linter-test-A.md\n',
 
-    'src/linter-test-A.md:6 MD001/heading-increment/header-increment Heading levels should only increment by one level at a time [Expected: h2; Actual: h3]\n',
-    'src/linter-test-A.md:10 indented-fence Fenced code shouldn\'t be indented by 1 to 3 spaces [Context: "   ```bash"]\n',
-    'src/linter-test-A.md:14 non-literal-fence-label Invalid language label in fenced code block\n',
-    'src/linter-test-A.md:21 fenced-code-in-quote Fenced code shouldn\'t be in quote\n',
-    'src/linter-test-A.md:29 validate-internal-links Broken link [image does not exist] [Context: "/red-circle.png"]\n',
-    'src/linter-test-A.md:35 validate-internal-links Broken link [file exists, but invalid anchor] [Context: "/another-project/subproject/article#anchor"]\n',
-    'src/linter-test-A.md:37 validate-internal-links Broken link [file does not exist] [Context: "/foliant-md-linter/subproject/article"]\n',
+    'src/linter-test-A.md:8 MD001/heading-increment/header-increment Heading levels should only increment by one level at a time [Expected: h2; Actual: h3]\n',
+    'src/linter-test-A.md:12 indented-fence Fenced code shouldn\'t be indented by 1 to 3 spaces [Context: "   ```bash"]\n',
+    'src/linter-test-A.md:16 non-literal-fence-label Invalid language label in fenced code block\n',
+    'src/linter-test-A.md:23 fenced-code-in-quote Fenced code shouldn\'t be in quote\n',
+    'src/linter-test-A.md:31 validate-internal-links Broken link [image does not exist] [Context: "/red-circle.png"]\n',
+    'src/linter-test-A.md:37 validate-internal-links Broken link [file exists, but invalid anchor] [Context: "/another-project/subproject/article#anchor"]\n',
+    'src/linter-test-A.md:39 validate-internal-links Broken link [file does not exist] [Context: "/foliant-md-linter/subproject/article"]\n',
 
     '--------------------------------------------------------------------------------\n',
 
     'FILE: src/subproject/article.md\n',
 
-    'src/subproject/article.md:6 validate-internal-links Broken link [invalid local anchor] [Context: "#anchor"]\n',
+    'src/subproject/article.md:8 validate-internal-links Broken link [invalid local anchor] [Context: "#anchor"]\n',
 
     `Full markdownlint log see in ${path.join(cwd, '.markdownlint_slim.log')}\n`,
 
@@ -969,11 +969,11 @@ test('essential -s alt-src -v', async () => {
 
     'FILE: alt-src/linter-test-B.md\n',
 
-    'alt-src/linter-test-B.md:6 non-literal-fence-label Invalid language label in fenced code block\n',
-    'alt-src/linter-test-B.md:17 MD001/heading-increment/header-increment Heading levels should only increment by one level at a time [Expected: h2; Actual: h3]\n',
-    'alt-src/linter-test-B.md:19 fenced-code-in-quote Fenced code shouldn\'t be in quote\n',
-    'alt-src/linter-test-B.md:23 validate-internal-links Broken link [image does not exist] [Context: "/red-circle.png"]\n',
-    'alt-src/linter-test-B.md:27 indented-fence Fenced code shouldn\'t be indented by 1 to 3 spaces [Context: "   ```bash"]\n',
+    'alt-src/linter-test-B.md:8 non-literal-fence-label Invalid language label in fenced code block\n',
+    'alt-src/linter-test-B.md:19 MD001/heading-increment/header-increment Heading levels should only increment by one level at a time [Expected: h2; Actual: h3]\n',
+    'alt-src/linter-test-B.md:21 fenced-code-in-quote Fenced code shouldn\'t be in quote\n',
+    'alt-src/linter-test-B.md:25 validate-internal-links Broken link [image does not exist] [Context: "/red-circle.png"]\n',
+    'alt-src/linter-test-B.md:29 indented-fence Fenced code shouldn\'t be indented by 1 to 3 spaces [Context: "   ```bash"]\n',
 
     `Full markdownlint log see in ${path.join(cwd, '.markdownlint_slim.log')}\n`,
 
@@ -1003,8 +1003,8 @@ test('essential -s alt-src -v -c', async () => {
 
     'FILE: alt-src/linter-test-B.md\n',
 
-    'alt-src/linter-test-B.md:17 MD001/heading-increment/header-increment Heading levels should only increment by one level at a time [Expected: h2; Actual: h3]\n',
-    'alt-src/linter-test-B.md:31 MD024/no-duplicate-heading/no-duplicate-header Multiple headings with the same content [Context: "### MD001: Heading levels shou..."]\n',
+    'alt-src/linter-test-B.md:19 MD001/heading-increment/header-increment Heading levels should only increment by one level at a time [Expected: h2; Actual: h3]\n',
+    'alt-src/linter-test-B.md:33 MD024/no-duplicate-heading/no-duplicate-header Multiple headings with the same content [Context: "### MD001: Heading levels shou..."]\n',
 
     `Full markdownlint log see in ${path.join(cwd, '.markdownlint_slim.log')}\n`,
 
@@ -1034,8 +1034,8 @@ test('essential -s alt-src -v -c -f', async () => {
 
     'FILE: alt-src/linter-test-B.md\n',
 
-    'alt-src/linter-test-B.md:17 MD001/heading-increment/header-increment Heading levels should only increment by one level at a time [Expected: h2; Actual: h3]\n',
-    'alt-src/linter-test-B.md:31 MD024/no-duplicate-heading/no-duplicate-header Multiple headings with the same content [Context: "### MD001: Heading levels shou..."]\n',
+    'alt-src/linter-test-B.md:19 MD001/heading-increment/header-increment Heading levels should only increment by one level at a time [Expected: h2; Actual: h3]\n',
+    'alt-src/linter-test-B.md:33 MD024/no-duplicate-heading/no-duplicate-header Multiple headings with the same content [Context: "### MD001: Heading levels shou..."]\n',
 
     `Full markdownlint log see in ${path.join(cwd, '.markdownlint_slim.log')}\n`,
 
@@ -1097,19 +1097,19 @@ test('full-check -v', async () => {
 
     'FILE: src/linter-test-A.md\n',
 
-    'src/linter-test-A.md:6 MD001/heading-increment/header-increment Heading levels should only increment by one level at a time [Expected: h2; Actual: h3]\n',
-    'src/linter-test-A.md:10 indented-fence Fenced code shouldn\'t be indented by 1 to 3 spaces [Context: "   ```bash"]\n',
-    'src/linter-test-A.md:14 non-literal-fence-label Invalid language label in fenced code block\n',
-    'src/linter-test-A.md:21 fenced-code-in-quote Fenced code shouldn\'t be in quote\n',
-    'src/linter-test-A.md:29 validate-internal-links Broken link [image does not exist] [Context: "/red-circle.png"]\n',
-    'src/linter-test-A.md:33 validate-internal-links Broken link [file does not exist] [Context: "/another-project/subproject/article"]\n',
-    'src/linter-test-A.md:35 validate-internal-links Broken link [file does not exist] [Context: "/another-project/subproject/article#anchor"]\n',
+    'src/linter-test-A.md:8 MD001/heading-increment/header-increment Heading levels should only increment by one level at a time [Expected: h2; Actual: h3]\n',
+    'src/linter-test-A.md:12 indented-fence Fenced code shouldn\'t be indented by 1 to 3 spaces [Context: "   ```bash"]\n',
+    'src/linter-test-A.md:16 non-literal-fence-label Invalid language label in fenced code block\n',
+    'src/linter-test-A.md:23 fenced-code-in-quote Fenced code shouldn\'t be in quote\n',
+    'src/linter-test-A.md:31 validate-internal-links Broken link [image does not exist] [Context: "/red-circle.png"]\n',
+    'src/linter-test-A.md:35 validate-internal-links Broken link [file does not exist] [Context: "/another-project/subproject/article"]\n',
+    'src/linter-test-A.md:37 validate-internal-links Broken link [file does not exist] [Context: "/another-project/subproject/article#anchor"]\n',
 
     '--------------------------------------------------------------------------------\n',
 
     'FILE: src/subproject/article.md\n',
 
-    'src/subproject/article.md:6 validate-internal-links Broken link [invalid local anchor] [Context: "#anchor"]\n',
+    'src/subproject/article.md:8 validate-internal-links Broken link [invalid local anchor] [Context: "#anchor"]\n',
 
     `Full markdownlint log see in ${path.join(cwd, '.markdownlint_slim.log')}\n`,
 
@@ -1147,19 +1147,19 @@ test('full-check -v -p another-project', async () => {
 
     'FILE: src/linter-test-A.md\n',
 
-    'src/linter-test-A.md:6 MD001/heading-increment/header-increment Heading levels should only increment by one level at a time [Expected: h2; Actual: h3]\n',
-    'src/linter-test-A.md:10 indented-fence Fenced code shouldn\'t be indented by 1 to 3 spaces [Context: "   ```bash"]\n',
-    'src/linter-test-A.md:14 non-literal-fence-label Invalid language label in fenced code block\n',
-    'src/linter-test-A.md:21 fenced-code-in-quote Fenced code shouldn\'t be in quote\n',
-    'src/linter-test-A.md:29 validate-internal-links Broken link [image does not exist] [Context: "/red-circle.png"]\n',
-    'src/linter-test-A.md:35 validate-internal-links Broken link [file exists, but invalid anchor] [Context: "/another-project/subproject/article#anchor"]\n',
-    'src/linter-test-A.md:37 validate-internal-links Broken link [file does not exist] [Context: "/foliant-md-linter/subproject/article"]\n',
+    'src/linter-test-A.md:8 MD001/heading-increment/header-increment Heading levels should only increment by one level at a time [Expected: h2; Actual: h3]\n',
+    'src/linter-test-A.md:12 indented-fence Fenced code shouldn\'t be indented by 1 to 3 spaces [Context: "   ```bash"]\n',
+    'src/linter-test-A.md:16 non-literal-fence-label Invalid language label in fenced code block\n',
+    'src/linter-test-A.md:23 fenced-code-in-quote Fenced code shouldn\'t be in quote\n',
+    'src/linter-test-A.md:31 validate-internal-links Broken link [image does not exist] [Context: "/red-circle.png"]\n',
+    'src/linter-test-A.md:37 validate-internal-links Broken link [file exists, but invalid anchor] [Context: "/another-project/subproject/article#anchor"]\n',
+    'src/linter-test-A.md:39 validate-internal-links Broken link [file does not exist] [Context: "/foliant-md-linter/subproject/article"]\n',
 
     '--------------------------------------------------------------------------------\n',
 
     'FILE: src/subproject/article.md\n',
 
-    'src/subproject/article.md:6 validate-internal-links Broken link [invalid local anchor] [Context: "#anchor"]\n',
+    'src/subproject/article.md:8 validate-internal-links Broken link [invalid local anchor] [Context: "#anchor"]\n',
 
     `Full markdownlint log see in ${path.join(cwd, '.markdownlint_slim.log')}\n`,
 
@@ -1197,11 +1197,11 @@ test('full-check -s alt-src -v', async () => {
 
     'FILE: alt-src/linter-test-B.md\n',
 
-    'alt-src/linter-test-B.md:6 non-literal-fence-label Invalid language label in fenced code block\n',
-    'alt-src/linter-test-B.md:17 MD001/heading-increment/header-increment Heading levels should only increment by one level at a time [Expected: h2; Actual: h3]\n',
-    'alt-src/linter-test-B.md:19 fenced-code-in-quote Fenced code shouldn\'t be in quote\n',
-    'alt-src/linter-test-B.md:23 validate-internal-links Broken link [image does not exist] [Context: "/red-circle.png"]\n',
-    'alt-src/linter-test-B.md:27 indented-fence Fenced code shouldn\'t be indented by 1 to 3 spaces [Context: "   ```bash"]\n',
+    'alt-src/linter-test-B.md:8 non-literal-fence-label Invalid language label in fenced code block\n',
+    'alt-src/linter-test-B.md:19 MD001/heading-increment/header-increment Heading levels should only increment by one level at a time [Expected: h2; Actual: h3]\n',
+    'alt-src/linter-test-B.md:21 fenced-code-in-quote Fenced code shouldn\'t be in quote\n',
+    'alt-src/linter-test-B.md:25 validate-internal-links Broken link [image does not exist] [Context: "/red-circle.png"]\n',
+    'alt-src/linter-test-B.md:29 indented-fence Fenced code shouldn\'t be indented by 1 to 3 spaces [Context: "   ```bash"]\n',
 
     `Full markdownlint log see in ${path.join(cwd, '.markdownlint_slim.log')}\n`,
 
@@ -1233,8 +1233,8 @@ test('full-check -s alt-src -v -c', async () => {
 
     'FILE: alt-src/linter-test-B.md\n',
 
-    'alt-src/linter-test-B.md:17 MD001/heading-increment/header-increment Heading levels should only increment by one level at a time [Expected: h2; Actual: h3]\n',
-    'alt-src/linter-test-B.md:31 MD024/no-duplicate-heading/no-duplicate-header Multiple headings with the same content [Context: "### MD001: Heading levels shou..."]\n',
+    'alt-src/linter-test-B.md:19 MD001/heading-increment/header-increment Heading levels should only increment by one level at a time [Expected: h2; Actual: h3]\n',
+    'alt-src/linter-test-B.md:33 MD024/no-duplicate-heading/no-duplicate-header Multiple headings with the same content [Context: "### MD001: Heading levels shou..."]\n',
 
     `Full markdownlint log see in ${path.join(cwd, '.markdownlint_slim.log')}\n`,
 
@@ -1267,8 +1267,8 @@ test('full-check -s alt-src -v -c -l', async () => {
 
     'FILE: alt-src/linter-test-B.md\n',
 
-    'alt-src/linter-test-B.md:17 MD001/heading-increment/header-increment Heading levels should only increment by one level at a time [Expected: h2; Actual: h3]\n',
-    'alt-src/linter-test-B.md:31 MD024/no-duplicate-heading/no-duplicate-header Multiple headings with the same content [Context: "### MD001: Heading levels shou..."]\n',
+    'alt-src/linter-test-B.md:19 MD001/heading-increment/header-increment Heading levels should only increment by one level at a time [Expected: h2; Actual: h3]\n',
+    'alt-src/linter-test-B.md:33 MD024/no-duplicate-heading/no-duplicate-header Multiple headings with the same content [Context: "### MD001: Heading levels shou..."]\n',
 
     `Full markdownlint log see in ${path.join(cwd, '.markdownlint_slim.log')}\n`,
 
@@ -1304,8 +1304,8 @@ test('full-check -s alt-src -v -c -f', async () => {
 
     'FILE: alt-src/linter-test-B.md\n',
 
-    'alt-src/linter-test-B.md:17 MD001/heading-increment/header-increment Heading levels should only increment by one level at a time [Expected: h2; Actual: h3]\n',
-    'alt-src/linter-test-B.md:31 MD024/no-duplicate-heading/no-duplicate-header Multiple headings with the same content [Context: "### MD001: Heading levels shou..."]\n',
+    'alt-src/linter-test-B.md:19 MD001/heading-increment/header-increment Heading levels should only increment by one level at a time [Expected: h2; Actual: h3]\n',
+    'alt-src/linter-test-B.md:33 MD024/no-duplicate-heading/no-duplicate-header Multiple headings with the same content [Context: "### MD001: Heading levels shou..."]\n',
 
     `Full markdownlint log see in ${path.join(cwd, '.markdownlint_slim.log')}\n`,
 
@@ -1349,8 +1349,8 @@ test('print -v', async () => {
     'Checked 1 files\n',
     'Found 2 critical formatting errors\n',
     'FILE: alt-src/linter-test-B.md\n',
-    'alt-src/linter-test-B.md:17 MD001/heading-increment/header-increment Heading levels should only increment by one level at a time [Expected: h2; Actual: h3]\n',
-    'alt-src/linter-test-B.md:31 MD024/no-duplicate-heading/no-duplicate-header Multiple headings with the same content [Context: "### MD001: Heading levels shou..."]\n',
+    'alt-src/linter-test-B.md:19 MD001/heading-increment/header-increment Heading levels should only increment by one level at a time [Expected: h2; Actual: h3]\n',
+    'alt-src/linter-test-B.md:33 MD024/no-duplicate-heading/no-duplicate-header Multiple headings with the same content [Context: "### MD001: Heading levels shou..."]\n',
     `Full markdownlint log see in ${path.join(cwd, '.markdownlint_slim.log')}\n`,
     'Found 2 styleguide and formatting errors\n',
     `Full markdownlint log see in ${path.join(cwd, '.markdownlint_full.log')}\n`,

--- a/test/no-errors-src/linter-test-no-errors.md
+++ b/test/no-errors-src/linter-test-no-errors.md
@@ -1,3 +1,6 @@
+---
+tags: none
+---
 # Linter test with no errors
 
 ## Heading

--- a/test/no-errors-src/linter-test-no-errors.md
+++ b/test/no-errors-src/linter-test-no-errors.md
@@ -1,6 +1,8 @@
 ---
-tags: none
+tags:
+    - none
 ---
+
 # Linter test with no errors
 
 ## Heading

--- a/test/src/linter-test-A.md
+++ b/test/src/linter-test-A.md
@@ -1,3 +1,6 @@
+---
+tags: none
+---
 # Linter test A
 
 ### MD001: Heading levels should only increment by one level at a time

--- a/test/src/linter-test-A.md
+++ b/test/src/linter-test-A.md
@@ -1,6 +1,8 @@
 ---
-tags: none
+tags:
+    - none
 ---
+
 # Linter test A
 
 ### MD001: Heading levels should only increment by one level at a time

--- a/test/src/subproject/article.md
+++ b/test/src/subproject/article.md
@@ -1,6 +1,8 @@
 ---
-tags: none
+tags:
+    - none
 ---
+
 # Article
 
 [broken local link](#anchor)

--- a/test/src/subproject/article.md
+++ b/test/src/subproject/article.md
@@ -1,3 +1,6 @@
+---
+tags: none
+---
 # Article
 
 [broken local link](#anchor)


### PR DESCRIPTION
- Add a frontmatter tag check
- [x] fix the `markdownlint-rules-foliant` version after merge [PR](https://github.com/holamgadol/markdownlint-foliant-rules/pull/11)


python script for fix line numbers (used for updating `linter.spec.js`):
```py
import re

with open('./foliant-md-linter/test/linter.spec.js') as f:
    text = f.read()

    regex = re.compile(r'(?P<pref>\.md\:)(?P<linenum>\d+)')

    def _sub(m):
        pref = m.group('pref')
        linenum = int(m.group('linenum'))
        newnum = linenum + 3

        return f'{pref}{newnum}'

    newtext = regex.sub(_sub, text)

with open('./foliant-md-linter/test/linter.spec.js', 'w') as f:
   f.write(newtext)
```