### PR TITLE
fix: multi streaming output

### DIFF
--- a/linter.js
+++ b/linter.js
@@ -25,6 +25,7 @@ const {
 const program = new Command()
 const cwd = process.cwd().toString()
 const isWin = process.platform === 'win32'
+const isMac = process.platform === 'darwin'
 const shell = (isWin === true) ? 'cmd.exe' : '/bin/bash'
 let logicalProcessorCount = 1
 if (os.cpus().length > 2) {
@@ -340,6 +341,9 @@ const commandsGen = function (src = defaultSrc, configPath = '', project = '',
   commands.markdownlint = `${commands.createMarkdownlintConfig} && ${execPath}/markdownlint-cli2${fix} ${filesArgMdLint} ${writeLog(markdownLintLog)}`
 
   // Markdownlintcheck
+  if (isMac) {
+    multiStream = `${multiStream} -S1024`
+  }
   commands.markdownlinkcheckSrcUnix = `find ${filesArgMdLinkCheck} -type f -name '*.md' -print0 | xargs -0 ${multiStream} -I{} bash -c 'tempfile=$(mktemp); ${execPath}/markdown-link-check -p -c ${path.join(__dirname, '/configs/mdLinkCheckConfig.json')} {} > "$tempfile" 2>&1; cat "$tempfile"; rm "$tempfile"' | tee ${path.join(cwd, markdownLinkCheckLog)}`
 
   commands.markdownlinkcheckSrcWin = `del ${path.join(cwd, markdownLinkCheckLog)} & forfiles /P ${filesArgMdLinkCheck} /S /M *.md /C "cmd /c npx markdown-link-check @file -p -c ${path.join(__dirname, '/configs/mdLinkCheckConfig.json')} ${writeLog(path.join(cwd, markdownLinkCheckLog))}"`

--- a/linter.js
+++ b/linter.js
@@ -260,6 +260,7 @@ const commandsGen = function (src = defaultSrc, configPath = '', project = '',
   let filesArgMdLinkCheck = (isWin === true) ? `${src}` : `${src}/`
   let existIncludesMap = false
   let listOfFiles = []
+  let multiStream = '-P1'
 
   if (project) {
     args.push(`-p "${project}"`)
@@ -306,6 +307,11 @@ const commandsGen = function (src = defaultSrc, configPath = '', project = '',
     args.push(`--includes-map ${defaultIncludesMap}`)
   }
 
+  // Multi stream markdownlinkcheck
+  if (format === 'cjs') {
+    multiStream = `-P${logicalProcessorCount}`
+  }
+
   if (configPath && fs.existsSync(configPath)) {
     args.push(`-c ${configPath}`)
   }
@@ -334,7 +340,7 @@ const commandsGen = function (src = defaultSrc, configPath = '', project = '',
   commands.markdownlint = `${commands.createMarkdownlintConfig} && ${execPath}/markdownlint-cli2${fix} ${filesArgMdLint} ${writeLog(markdownLintLog)}`
 
   // Markdownlintcheck
-  commands.markdownlinkcheckSrcUnix = `find ${filesArgMdLinkCheck} -type f -name '*.md' -print0 | xargs -0 -n1 -P${logicalProcessorCount} ${execPath}/markdown-link-check -p -c ${path.join(__dirname, '/configs/mdLinkCheckConfig.json')} ${writeLog(path.join(cwd, markdownLinkCheckLog))}`
+  commands.markdownlinkcheckSrcUnix = `find ${filesArgMdLinkCheck} -type f -name '*.md' -print0 | xargs -0 -n1 ${multiStream} ${execPath}/markdown-link-check -p -c ${path.join(__dirname, '/configs/mdLinkCheckConfig.json')} ${writeLog(path.join(cwd, markdownLinkCheckLog))}`
   commands.markdownlinkcheckSrcWin = `del ${path.join(cwd, markdownLinkCheckLog)} & forfiles /P ${filesArgMdLinkCheck} /S /M *.md /C "cmd /c npx markdown-link-check @file -p -c ${path.join(__dirname, '/configs/mdLinkCheckConfig.json')} ${writeLog(path.join(cwd, markdownLinkCheckLog))}"`
 
   commands.markdownlinkcheck = (isWin === true) ? commands.markdownlinkcheckSrcWin : commands.markdownlinkcheckSrcUnix

--- a/linter.js
+++ b/linter.js
@@ -261,7 +261,7 @@ const commandsGen = function (src = defaultSrc, configPath = '', project = '',
   let filesArgMdLinkCheck = (isWin === true) ? `${src}` : `${src}/`
   let existIncludesMap = false
   let listOfFiles = []
-  let multiStream = '-P1'
+  let multiStream = `-P${logicalProcessorCount}`
 
   if (project) {
     args.push(`-p "${project}"`)
@@ -306,11 +306,6 @@ const commandsGen = function (src = defaultSrc, configPath = '', project = '',
     generateIncludesMap(foliantConfig, debug)
     updateListOfFiles(src, defaultIncludesMap, listOfFiles)
     args.push(`--includes-map ${defaultIncludesMap}`)
-  }
-
-  // Multi stream markdownlinkcheck
-  if (format === 'cjs') {
-    multiStream = `-P${logicalProcessorCount}`
   }
 
   if (configPath && fs.existsSync(configPath)) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "foliant-md-linter",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "CLI tool for linting Foliant markdown sources",
   "license": "MIT",
   "homepage": "https://github.com/holamgadol/foliant-md-linter",


### PR DESCRIPTION
Fixed the error of incorrect output of external links check related to the execution of a command `markdown-link-check` in multi threads.